### PR TITLE
Automatische PR-previews (closes #3)

### DIFF
--- a/.github/workflows/deploy-main.yml
+++ b/.github/workflows/deploy-main.yml
@@ -1,0 +1,42 @@
+name: Deploy production site to gh-pages
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: write
+
+concurrency:
+  group: pages-main
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v4
+        with:
+          path: main
+
+      - name: Checkout gh-pages
+        uses: actions/checkout@v4
+        with:
+          ref: gh-pages
+          path: gh-pages
+
+      - name: Sync site files into gh-pages root (keep pr-preview/ intact)
+        run: |
+          cp main/index.html gh-pages/index.html
+          cp main/README.md gh-pages/README.md
+          cp main/LICENSE gh-pages/LICENSE
+
+      - name: Commit and push if changed
+        working-directory: gh-pages
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add -A -- index.html README.md LICENSE
+          git diff --cached --quiet && echo "Geen wijziging" || git commit -m "Deploy production van main@${GITHUB_SHA::7}"
+          git push

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -1,0 +1,27 @@
+name: PR preview
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, closed]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: pr-preview-${{ github.event.number }}
+  cancel-in-progress: true
+
+jobs:
+  preview:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Deploy or remove PR preview
+        uses: rossjrw/pr-preview-action@v1
+        with:
+          source-dir: .
+          preview-branch: gh-pages
+          umbrella-dir: pr-preview

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,8 +61,19 @@ Squash-gedrag op de kaart: gesquashte commits krijgen `c.squashed = true` en wor
 1. Branch vanaf `main` (`feat/...` of `fix/...`) — nooit direct op `main` committen.
 2. Pas `index.html` aan; werk zo nodig `test/smoketest.js` mee bij.
 3. **Draai `node test/smoketest.js` — moet 100% groen zijn** vóór je de PR als klaar beschouwt. Voeg voor nieuw gedrag nieuwe asserts toe.
-4. Open een PR met een duidelijke omschrijving in gewone taal (de reviewer is niet altijd technisch).
+4. Open een PR met een duidelijke omschrijving in gewone taal (de reviewer is niet altijd technisch). **Elke PR die de simulatie zelf verandert (dus niet alleen CI/docs) krijgt een expliciete "wat te checken in de preview"-regel**, bijv. "Klik X aan, kijk of Y verschijnt" — de automatische preview-link (zie hieronder) toont alleen dát er iets is, niet wát. Zonder die regel is een kale link net zo onduidelijk als geen link.
 5. **Mergen doet een mens** (repo-eigenaar beslist) — een agent merget nooit zelf. Onthoud: merge = binnen een minuut live op de Pages-URL.
+
+## PR-previews
+
+Elke PR krijgt automatisch een comment met een klikbare preview-link (`pr-preview/pr-<nummer>/`
+op de `gh-pages`-branch, via `rossjrw/pr-preview-action` in `.github/workflows/pr-preview.yml`).
+Productie deployt via een aparte workflow (`deploy-main.yml`) die bij elke push naar `main`
+de site-bestanden naar `gh-pages`-root synct — de preview-mappen blijven daarbij intact.
+
+Een PR die alleen CI/workflows/documentatie wijzigt (geen `index.html`) toont in de preview
+terecht niets anders dan de huidige site — meld dat expliciet in zo'n PR-tekst, anders lijkt
+het alsof de preview niet werkt.
 
 ## Herkomst
 


### PR DESCRIPTION
Closes lxdg-technologies/git-routekaart-demo#3.

## Wat

Elke PR krijgt voortaan automatisch een klikbare preview-link als comment, vóórdat er gemerged wordt.

## Hoe het werkt

* Pages-bron is omgezet van "main branch" naar de `gh-pages`-branch (productie-URL geverifieerd ongewijzigd vóór deze PR).
* `deploy-main.yml`: bij elke push naar main, synct de site-bestanden naar `gh-pages`-root.
* `pr-preview.yml`: gebruikt [`rossjrw/pr-preview-action`](<https://github.com/rossjrw/pr-preview-action>) om elke PR naar `pr-preview/pr-<nummer>/` te deployen, met automatische comment + link. Ruimt zichzelf op zodra de PR sluit.

## Zelfbewijs

Deze PR triggert de nieuwe workflow op zichzelf — de comment die zo verschijnt met de preview-link ís de test. Als die comment een werkende link bevat, werkt de feature.

🤖 Generated with [Claude Code](<https://claude.com/claude-code>)