### PR TITLE
[agent:core] show v1.1.0 release badge

### DIFF
--- a/index.html
+++ b/index.html
@@ -58,6 +58,7 @@
   .legend { display: flex; flex-wrap: wrap; gap: .4rem .9rem; padding: .45rem .5rem .55rem; border-top: 1px solid var(--line); font-size: .8rem; color: var(--ink-soft); }
   .legend span { display: inline-flex; align-items: center; gap: .35rem; }
   .legend i { width: 18px; height: 5px; border-radius: 3px; display: inline-block; }
+  .release-badge { display: flex; justify-content: flex-end; padding: .25rem .5rem .55rem; color: var(--ink-soft); font-family: var(--mono); font-size: .75rem; }
 
   /* ── omgevingen ── */
   .envs { display: flex; align-items: stretch; gap: .3rem; }
@@ -162,6 +163,7 @@
     <div class="card" id="map-card">
       <div id="map-scroll"></div>
       <div class="legend" id="legend"></div>
+      <div class="release-badge">release: v1.1.0</div>
     </div>
 
     <div class="card" id="omg-uitleg">

--- a/index.html
+++ b/index.html
@@ -58,7 +58,7 @@
   .legend { display: flex; flex-wrap: wrap; gap: .4rem .9rem; padding: .45rem .5rem .55rem; border-top: 1px solid var(--line); font-size: .8rem; color: var(--ink-soft); }
   .legend span { display: inline-flex; align-items: center; gap: .35rem; }
   .legend i { width: 18px; height: 5px; border-radius: 3px; display: inline-block; }
-  .release-badge { display: flex; justify-content: flex-end; padding: .25rem .5rem .55rem; color: var(--ink-soft); font-family: var(--mono); font-size: .75rem; }
+  .release-badge { position: fixed; right: 1.25rem; bottom: 1.25rem; z-index: 10; padding: .35rem .65rem; border: 1px solid var(--line); border-radius: 999px; background: var(--panel); color: var(--ink-soft); box-shadow: 0 2px 8px rgb(0 0 0 / .12); font-family: var(--mono); font-size: .75rem; }
 
   /* ── omgevingen ── */
   .envs { display: flex; align-items: stretch; gap: .3rem; }
@@ -163,7 +163,6 @@
     <div class="card" id="map-card">
       <div id="map-scroll"></div>
       <div class="legend" id="legend"></div>
-      <div class="release-badge">release: v1.1.0</div>
     </div>
 
     <div class="card" id="omg-uitleg">
@@ -278,6 +277,8 @@
     </div>
   </div>
 </div>
+
+<div class="release-badge">release: v1.1.0</div>
 
 <script>
 (() => {

--- a/test/smoketest.js
+++ b/test/smoketest.js
@@ -48,6 +48,8 @@ const assert = (cond, msg) => {
 // helper: vind de laatst gemaakte dynamische knop met deze tekst
 const findBtn = txt => created.filter(e => e.tag === "button" && e.textContent.includes(txt)).pop();
 
+assert(html.includes('class="release-badge">release: v1.1.0<'), "kaart toont de echte release-badge v1.1.0");
+
 assert(byIdMap["env-test"].textContent === "v0.1.0", "test start op v0.1.0");
 assert(byIdMap["env-live"].textContent === "v0.1.0", "live start op v0.1.0");
 assert(byIdMap["btn-promote"].disabled === true, "promote start uitgeschakeld (test == live)");


### PR DESCRIPTION
## Wat verandert er

De kaart toont nu rechtsonder in het scherm, los van de kaartcontainer, de echte GitHub-release als `release: v1.1.0`. De bestaande git-tag en GitHub Release `v1.1.0` bestaan al; deze PR maakt dat ook zichtbaar in de simulatie zelf.

## Wat te checken in de preview

Open de preview en kijk rechtsonder in het viewport — buiten de kaart — of de losse badge `release: v1.1.0` zichtbaar is.

Preview: https://lxdg-technologies.github.io/git-routekaart-demo/pr-preview/pr-6/?v=eba3432

## Verificatie

- `node test/smoketest.js` — groen
- `git diff --check` — groen
- preview visueel gecontroleerd: badge staat los rechtsonder

Mergen doet Rob zelf; merge naar `main` deployt automatisch naar GitHub Pages.