### PR TITLE
Verwijzing naar de privé-companion-repo toevoegen

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,15 @@ Interactieve simulatie van een moderne git-werkstroom: **issue → branch → PR
 - Branchen vanaf een andere branch
 - Live terugzetten naar een eerdere versie
 
+## De werkwijze in de praktijk
+
+Deze simulatie is de **generieke** versie: hij leert de route, zonder afspraken van een specifieke organisatie.
+
+De werkwijze zoals wij die zelf toepassen — rolverdeling, de route van issue tot live, en de regels die daarbij gelden — staat in een **privé-companion-repo**: [`lxdg-technologies/git-routekaart`](https://github.com/lxdg-technologies/git-routekaart).
+
+- **Heb je toegang?** Dan opent die link direct.
+- **Nog geen toegang?** Dan zie je een 404-pagina. Open een [issue in deze repo](https://github.com/lxdg-technologies/git-routekaart-demo/issues) om toegang aan te vragen.
+
 ## Lokaal draaien
 
 Download of clone deze repo en open `index.html` in een browser. Eén bestand, geen build, geen server.

--- a/WERKWIJZE.md
+++ b/WERKWIJZE.md
@@ -8,6 +8,8 @@ Een leermiddel voor mensen **zonder software-achtergrond** die git van nul leren
 
 Alles wat je toevoegt moet die ene persoon helpen. Een uitbreiding die alleen een programmeur waardeert, hoort hier niet.
 
+**Deze repo blijft generiek.** Geen organisatienamen, machines, personen, interne URL's of projectafspraken. Alles wat wél over een specifieke organisatie gaat, hoort in een eigen privé-companion-repo — voor dit project is dat [`lxdg-technologies/git-routekaart`](https://github.com/lxdg-technologies/git-routekaart), waar de werkelijke rolverdeling, route en regels staan. Zie het `README` voor hoe je toegang aanvraagt.
+
 ## 2. Wat de simulatie nabootst
 
 Ben je nieuw: lees dit hoofdstuk eerst. Daarna weet je waar elke knop in de simulatie in het echt over gaat.
@@ -94,6 +96,7 @@ Wat dat wél doet: voorkomen dat er ongemerkt iets binnenkomt. Wat het níet doe
 
 Nieuwste bovenaan. Eén regel per besluit, altijd met datum.
 
+- **03-08-2026** — Verwijzing naar de privé-companion-repo toegevoegd in `README.md`. De knip blijft: publiek = generiek leermiddel, privé = de werkwijze van de organisatie zelf.
 - **03-08-2026** — v1 verklaard tot eindstreep. Alles wat verder gaat dan de keten van issue tot live valt onder v2 en wordt niet stilzwijgend toegevoegd.
 - **03-08-2026** — Dit bestand toegevoegd, omdat de bedoeling van de simulatie tot nu toe alleen uit de code viel af te leiden en elke sessie op een eigen interpretatie uitkwam.
 - **02-08-2026** — Rooktests testen gedrag of het uiteindelijke scherm, nooit de letterlijke brontekst van het script.


### PR DESCRIPTION
## Wat dit doet

Deze repo leert de git-route in generieke vorm. De werkwijze zoals een organisatie die zelf toepast — rolverdeling, afspraken, wie wat mag — hoort daar bewust niet in. Die staat sinds vandaag in een privé-companion-repo.

Deze PR legt de verbinding tussen de twee, zodat iemand die de simulatie vindt ook weet dát er een praktijkversie is en hoe hij daar toegang toe vraagt.

**Alleen documentatie.** `index.html`, `test/` en `sveltekit/` zijn niet aangeraakt.

## Twee wijzigingen

**`README.md`** — nieuwe sectie *"De werkwijze in de praktijk"*, boven *"Lokaal draaien"*. Verwijst naar `lxdg-technologies/git-routekaart` en legt uit wat je ziet met en zonder toegang. Toegang aanvragen gaat via een issue in déze repo — bewust geen e-mailadres in een publieke repo.

**`WERKWIJZE.md`** — hoofdstuk 1 zegt nu expliciet dat deze repo generiek blijft (geen organisatienamen, machines, personen of interne afspraken) en waar dat soort inhoud dan wél hoort. Plus een regel in het besluitenlogboek.

## Wat te controleren

- `node test/smoketest.js` → 56 checks groen, exitcode 0. De handboek-controle telt nog steeds 13 missies tegenover 13 regels op `af`; die tabel is niet aangeraakt. *(Lokaal gedraaid vóór het openen van deze PR.)*
- Open het `README` in de preview: de link naar de privé-repo geeft een 404 voor wie geen toegang heeft — dat is de bedoeling en staat er ook bij.

## Wat hier bewust NIET in zit

- Geen contactgegevens, e-mailadressen of namen in de publieke repo.
- Geen wijziging aan de simulatie of aan de leerdoelen-tabel.
