### PR TITLE
Fixes DCS-177 — werkwijze voor parallel werken vastgelegd

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,6 +69,23 @@ Squash-gedrag op de kaart: gesquashte commits krijgen `c.squashed = true` en wor
 4. Open een PR met een duidelijke omschrijving in gewone taal (de reviewer is niet altijd technisch). **Elke PR die de simulatie zelf verandert (dus niet alleen CI/docs) krijgt een expliciete "wat te checken in de preview"-regel**, bijv. "Klik X aan, kijk of Y verschijnt" — de automatische preview-link (zie hieronder) toont alleen dát er iets is, niet wát. Zonder die regel is een kale link net zo onduidelijk als geen link.
 5. **Mergen doet een mens** (repo-eigenaar beslist) — een agent merget nooit zelf. Onthoud: merge = binnen een minuut live op de Pages-URL.
 
+## Met meerdere mensen tegelijk werken
+
+**Git voegt per regel samen, niet per bestand.** Twee mensen die verschillende stukken van `index.html` aanpassen, gaan vanzelf goed samen. Een conflict ontstaat alleen als jullie dezelfde regels aanraken.
+
+**Elk issue begint met een regel `Raakt: <bestand of sectie>`.** Voor `index.html` gebruik je de sectienaam uit de bannerkoppen (`/* ==== SECTIE: KAART ==== */`). Twee taken in verschillende secties mogen tegelijk lopen; in dezelfde sectie doe je ze achter elkaar. De tien secties zijn:
+
+`THEMA`, `LAYOUT`, `RELEASE-BADGE`, `KAART`, `OMGEVINGEN`, `ACTIES`, `MISSIES`, `LOGBOEK`, `BEGRIPPEN`, `STATE`.
+
+**Vóór het openen van een PR:** haal de laatste `main` op, zet je werk daar bovenop, en draai de rooktest opnieuw. Dat vangt de meeste botsingen weg voordat iemand ze ziet.
+
+**Botst het toch?** Dat is routinewerk, geen storing:
+
+1. Bekijk beide versies naast elkaar.
+2. Kies wat blijft (of allebei, in de goede volgorde).
+3. Draai de rooktest opnieuw.
+4. Zet in de PR-tekst wat je gekozen hebt en waarom — die keuze moet zichtbaar zijn voor de beoordelaar.
+
 ## PR-previews
 
 Elke PR krijgt automatisch een comment met een klikbare preview-link (`pr-preview/pr-<nummer>/`

--- a/WERKWIJZE.md
+++ b/WERKWIJZE.md
@@ -72,7 +72,7 @@ Dit is geen achterstand. Dit zijn keuzes, met datum. Constateer je een van deze 
 |---|---|---|
 | Een tweede persoon die ook mergt | v1 leert de keten, niet het samenwerken. Zonder tweede hand beweegt de hoofdlijn nooit onder je voeten — dat hoort bij v2 | 03-08-2026 |
 | Een review-poort (goedkeuren / wijzigingen vragen) | Hoort niet in een nagespeelde omgeving thuis maar in de instellingen van een echte repo, waar hij echt tegenhoudt | 03-08-2026 |
-| Merge-conflicten | Het enige dat samenwerken spannend maakt, en juist daarom slecht na te spelen met knopjes. Kandidaat voor v2 | 03-08-2026 |
+| Merge-conflicten | Het enige dat samenwerken spannend maakt, en juist daarom slecht na te spelen met knopjes. Kandidaat voor v2. De werkwijze eromheen staat wél vast (zie `AGENTS.md`), alleen de simulatie speelt het niet na | 03-08-2026 |
 | Een controle die een merge tegenhoudt | Zelfde reden als de review-poort: echt of niet | 03-08-2026 |
 | Een kapotte live-omgeving | Rollback kun je nu oefenen zonder ooit paniek te voelen. Kandidaat voor v2 | 03-08-2026 |
 | Semver-nuance (major/minor) | Versienummers zijn bewust simpel (`v0.1.n`); versiebeleid is hier geen leerdoel | 29-07-2026 |
@@ -96,6 +96,7 @@ Wat dat wél doet: voorkomen dat er ongemerkt iets binnenkomt. Wat het níet doe
 
 Nieuwste bovenaan. Eén regel per besluit, altijd met datum.
 
+- **03-08-2026** — Werkwijze voor parallel werken vastgelegd: sectiemarkering in index.html, rooktest per gebied, en 'Raakt:' bovenaan elk issue.
 - **03-08-2026** — Verwijzing naar de privé-companion-repo toegevoegd in `README.md`. De knip blijft: publiek = generiek leermiddel, privé = de werkwijze van de organisatie zelf.
 - **03-08-2026** — v1 verklaard tot eindstreep. Alles wat verder gaat dan de keten van issue tot live valt onder v2 en wordt niet stilzwijgend toegevoegd.
 - **03-08-2026** — Dit bestand toegevoegd, omdat de bedoeling van de simulatie tot nu toe alleen uit de code viel af te leiden en elke sessie op een eigen interpretatie uitkwam.


### PR DESCRIPTION
## Wat verandert er

Raakt: `AGENTS.md` en `WERKWIJZE.md` — verder niets.

We durfden niet met meerdere mensen tegelijk aan deze repo te werken, omdat nergens stond hoe je vooraf ziet of twee taken elkaar raken, en wat je doet als het tóch botst. Dat staat nu vast:

- **`AGENTS.md`** krijgt een nieuw kopje "Met meerdere mensen tegelijk werken": git voegt samen per regel (niet per bestand), elk issue begint met `Raakt: <bestand of sectie>`, de tien sectienamen van `index.html` staan erbij, en de stappen bij een botsing (bekijken, kiezen, rooktest opnieuw, keuze uitleggen in de PR).
- **`WERKWIJZE.md`** — hoofdstuk 5: de regel over merge-conflicten aangevuld dat de werkwijze eromheen wél is vastgelegd (in `AGENTS.md`), maar dat de simulatie het niet naspeelt. Hoofdstuk 7: één nieuwe besluitregel bovenaan.

**De leerdoelen-tabel in hoofdstuk 4 van `WERKWIJZE.md` is niet aangeraakt** — geen regel toegevoegd, geen status gewijzigd. Ook geen nieuwe hoofdstukken en geen hernummering.

## Wat te checken in de preview

Dit is een documentatie-only wijziging (geen `index.html`) — de preview toont dus terecht niets anders dan de huidige site.

## Getest

- `node test/smoketest.js` → alle checks groen, exitcode 0, aantal controles ongewijzigd.
- Vlak voor het openen van deze PR de laatste `main` opgehaald en de branch daarbovenop gezet (main was niet verschoven) en de rooktest opnieuw gedraaid.
