### PR TITLE
Rooktest opsplitsen per gebied

### DIFF
--- a/test/checks/acties.js
+++ b/test/checks/acties.js
@@ -1,0 +1,39 @@
+// Controles rond de acties zelf: commit, PR, merge-vormen, startpunt kiezen en de missievoortgang.
+module.exports = async function acties({ assert, byIdMap, state, stappen }) {
+  stappen.opnieuw();
+  stappen.nieuwIssue();
+  stappen.maakBranch();
+  stappen.commit();
+  assert(byIdMap["btn-commit"].disabled === false, "commit-knop is actief op een branch");
+  stappen.commit();
+  assert(state().branches[state().active].head === state().commits[state().commits.length - 1].id, "branch-head volgt de laatste commit");
+  stappen.openPR();
+  assert(state().prs[0].state === "open", "open PR krijgt de status open");
+  stappen.mergeCommit();
+  stappen.promote();
+
+  stappen.mergeRonde("squash");
+  assert(state().mergeKinds.has("merge") && state().mergeKinds.has("squash"), "simulatie registreert beide merge-vormen");
+  stappen.revert();
+  assert(state().commits.at(-1).kind === "revert", "revert voegt een nieuwe revert-commit toe");
+  stappen.promote();
+  stappen.kiesRollback(1);
+  stappen.rollback();
+  stappen.verwijderBranch();
+
+  const initialCommitId = state().commits.find(c => c.msg === "initiële versie").id;
+  selectStart(initialCommitId);
+  assert(byIdMap["start-label"].textContent.includes(initialCommitId.slice(0, 5)), "gekozen ouder startpunt verschijnt in de DOM");
+  stappen.nieuwIssue();
+  stappen.maakBranch();
+  assert(state().branches[state().active].head === initialCommitId, "branch vanaf ouder commit gebruikt het gekozen startpunt");
+  stappen.nieuwIssue();
+  stappen.maakBranch();
+  stappen.commit();
+  const branchHead = state().branches[state().active].head;
+  selectStart(branchHead);
+  stappen.nieuwIssue();
+  stappen.maakBranch();
+  assert(state().branches[state().active].head === branchHead, "branch-van-branch gebruikt de gekozen branch-head");
+  assert(byIdMap["progress"].firstElementChild.style.width === "100%", "alle 13 missies voltooid → 100%");
+};

--- a/test/checks/begrippen.js
+++ b/test/checks/begrippen.js
@@ -1,0 +1,24 @@
+// Controles rond de begrippenlijst en de klikbare begrippen in het logboek.
+module.exports = async function begrippen({ assert, byIdMap, makeEl, glossaryResult, stappen }) {
+  assert((glossaryResult().match(/<details class="term-item"/g) || []).length === 26, "begrippenlijst rendert precies 26 termen");
+  assert(glossaryResult().includes("Voorbeeld:") && glossaryResult().includes("CI monitoring unavailable"), "elke begrippenlijst-entry bevat uitleg en voorbeeld");
+  const branchTerm = makeEl("details");
+  byIdMap["term-branch"] = branchTerm;
+  focusTerm("Branch");
+  assert(branchTerm.open === true, "focusTerm opent de gekozen glossary-entry");
+  assert(branchTerm.classList.contains("term-focus") && branchTerm.scrolled, "focusTerm markeert en scrollt naar de gekozen entry");
+
+  stappen.opnieuw();
+  stappen.nieuwIssue();
+  stappen.maakBranch();
+  assert(byIdMap["log"].children[0].innerHTML.includes("focusTerm('Branch')"), "branch-logregel bevat een klikbare Branch-term");
+  const branchLog = byIdMap["log"].children[0];
+  assert((branchLog.innerHTML.match(/class="log-term"/g) || []).length >= 1, "logregel rendert minstens één termknop");
+  stappen.commit();
+  stappen.commit();
+  stappen.openPR();
+  stappen.mergeCommit();
+  assert(byIdMap["log"].children[0].innerHTML.includes("focusTerm('CI (Continuous Integration)')"), "release-logregel bevat een klikbare CI-term");
+  const releaseLogTermCounts = [...byIdMap["log"].children[0].innerHTML.matchAll(/focusTerm\('([^']+)'\)/g)].map(m => m[1]);
+  assert(new Set(releaseLogTermCounts).size === releaseLogTermCounts.length, "elk begrip staat maximaal één keer in dezelfde logregel");
+};

--- a/test/checks/handboek.js
+++ b/test/checks/handboek.js
@@ -1,0 +1,11 @@
+// Handboek-controle: WERKWIJZE.md moet elke missie dekken.
+const fs = require("fs");
+const path = require("path");
+
+module.exports = async function handboek({ assert, byIdMap }) {
+  const werkwijze = fs.readFileSync(path.join(__dirname, "..", "..", "WERKWIJZE.md"), "utf8");
+  const regelsOpAf = (werkwijze.match(/^\|.*\|\s*af\s*\|\s*$/gm) || []).length;
+  const missiesInSimulatie = byIdMap["missie-list"].children.length;
+  assert(missiesInSimulatie === regelsOpAf,
+    `WERKWIJZE.md is bijgewerkt: ${missiesInSimulatie} missies in de simulatie, ${regelsOpAf} regels op 'af' in het handboek`);
+};

--- a/test/checks/kaart.js
+++ b/test/checks/kaart.js
@@ -1,0 +1,20 @@
+// Controles rond de metrokaart en de legenda: stations, lijnen, versielabels en vlaggen.
+module.exports = async function kaart({ assert, byIdMap, mapResult, stappen }) {
+  stappen.opnieuw();
+  assert(mapResult().includes("🧪🚀"), "kaart toont gecombineerde test/live-vlag bij de start");
+  assert(mapResult().includes("station-hit") && mapResult().includes("v0.1.0"), "kaart toont release-station en versielabel");
+  assert(mapResult().includes('role="button"') && mapResult().includes("branch-line"), "kaart rendert klikbare branch-lijn en stations");
+  assert(mapResult().includes("branch-line-hit") && mapResult().includes("station-hit"), "kaart rendert ruime klikdoelen");
+  assert(byIdMap["legend"].innerHTML.includes("release station"), "legenda benoemt release-stations");
+
+  stappen.mergeRonde("merge");
+  assert(mapResult().includes("v0.1.1") && mapResult().includes("release station v0.1.1"), "nieuwe release krijgt label op het juiste station");
+  stappen.promote();
+  assert(mapResult().includes("🧪🚀"), "kaart toont gecombineerde vlag na promotie");
+
+  stappen.mergeRonde("squash");
+  stappen.revert();
+  stappen.promote();
+  stappen.kiesRollback(1);
+  assert(mapResult().includes("terugrol naar v0.1.1"), "rollback-preview markeert het gekozen release-station");
+};

--- a/test/checks/omgevingen.js
+++ b/test/checks/omgevingen.js
@@ -1,0 +1,29 @@
+// Controles rond het omgevingsmodel: wat komt op test, wat op live, en wanneer.
+module.exports = async function omgevingen({ assert, byIdMap, state, stappen }) {
+  stappen.opnieuw();
+  assert(byIdMap["env-test"].textContent === "v0.1.0", "test start op v0.1.0");
+  assert(byIdMap["env-live"].textContent === "v0.1.0", "live start op v0.1.0");
+  assert(byIdMap["btn-promote"].disabled === true, "promote start uitgeschakeld als test gelijk is aan live");
+  assert(byIdMap["btn-revert"].disabled === true, "revert start uitgeschakeld zonder merge-head");
+
+  stappen.mergeRonde("merge");
+  assert(byIdMap["env-test"].textContent === "v0.1.1", "merge zet de nieuwe release op test");
+  assert(byIdMap["env-live"].textContent === "v0.1.0", "merge wijzigt live niet automatisch");
+  assert(byIdMap["btn-promote"].disabled === false, "promote wordt actief zodra test vooruitloopt");
+  stappen.promote();
+  assert(byIdMap["env-live"].textContent === "v0.1.1", "promote zet test exact naar live");
+  assert(byIdMap["btn-promote"].disabled === true, "promote schakelt uit zodra test gelijk is aan live");
+
+  stappen.mergeRonde("squash");
+  assert(byIdMap["env-test"].textContent === "v0.1.2", "squash-merge maakt v0.1.2 op test");
+  stappen.revert();
+  assert(byIdMap["env-test"].textContent === "v0.1.3", "revert maakt een nieuwe testversie");
+  assert(byIdMap["env-live"].textContent === "v0.1.1", "revert laat live ongemoeid");
+  stappen.promote();
+  assert(byIdMap["env-live"].textContent === "v0.1.3", "promote zet de gerepareerde versie op live");
+
+  stappen.kiesRollback(1);
+  stappen.rollback();
+  assert(byIdMap["env-live"].textContent === "v0.1.1" && byIdMap["env-test"].textContent === "v0.1.3", "rollback zet alleen live terug");
+  assert(state().env.liveCommit !== state().env.testCommit, "rollback houdt live en test op verschillende commits");
+};

--- a/test/checks/release-badge.js
+++ b/test/checks/release-badge.js
@@ -1,0 +1,31 @@
+// Controles rond de release-badge: gestempelde versie, fallback op GitHub en de releasehistorie.
+module.exports = async function releaseBadge({ assert, flush, byIdMap, fetchCalls, initialBadge, setFetchMode, stappen }) {
+  await flush(); await flush();
+  assert(initialBadge === "release: onbekend", "badge heeft een veilige beginwaarde vóór de fetch-response");
+  assert(byIdMap["release-badge-label"].textContent === "release: v9.9.9 +2 · abc1234", "badge toont de gestempelde versie, commits-ahead en sha");
+  assert(byIdMap["release-current-link"].textContent.includes("v9.9.9"), "badge-link toont de actieve versie");
+  assert(byIdMap["release-current-link"].href.endsWith("/v9.9.9"), "badge-link verwijst naar de actieve release");
+  assert(fetchCalls.includes("version.json"), "badge vraagt buildinformatie op via fetch");
+  assert(byIdMap["release-history"].classList.contains("release-badge") && byIdMap["release-history"].classList.contains("dev"), "badge krijgt de ontwikkelstatus in de DOM");
+  setFetchMode("fallback");
+  stappen.opnieuw(); await flush(); await flush();
+  assert(byIdMap["release-badge-label"].textContent === "release: v8.0.0 +4", "badge valt terug op GitHub-release plus compare-resultaat");
+  assert(byIdMap["release-build-note"].textContent.includes("nieuwste GitHub-release"), "fallback-note legt uit dat main nieuwer kan zijn");
+  assert(fetchCalls.some(url => url.includes("releases/latest")) && fetchCalls.some(url => url.includes("compare/")), "fallback gebruikt release- en compare-endpoint");
+  setFetchMode("version");
+  stappen.opnieuw(); await flush(); await flush();
+  assert(byIdMap["release-badge-label"].textContent.startsWith("release: v9.9.9"), "badge kan na fallback opnieuw een version-file gebruiken");
+  setFetchMode("history");
+  byIdMap["release-history"].open = true;
+  byIdMap["release-history"].dataset.historyLoaded = "false";
+  byIdMap["release-history"].ontoggle(); await flush(); await flush();
+  assert(byIdMap["release-history-list"].children.length === 2, "releasehistorie rendert alle ontvangen items");
+  const historyLink = byIdMap["release-history-list"].children[0].children[0];
+  assert(historyLink.textContent === "v9.9.8", "releasehistorie toont tagnaam");
+  assert(historyLink.href === "https://example.test/releases/v9.9.8" && historyLink.target === "_blank", "releasehistorie-item linkt naar release-notes in nieuw tabblad");
+  assert(byIdMap["release-history-list"].children[0].children[1].textContent.length > 0, "releasehistorie toont publicatiedatum");
+  setFetchMode("error");
+  byIdMap["release-history"].dataset.historyLoaded = "false";
+  byIdMap["release-history"].ontoggle(); await flush(); await flush();
+  assert(byIdMap["release-history-list"].children[0]._html.indexOf("Geen eerdere releases") >= 0, "releasehistorie toont een foutveilige lege toestand");
+};

--- a/test/smoketest.js
+++ b/test/smoketest.js
@@ -1,5 +1,7 @@
 // Headless rooktest voor index.html — draai met: node test/smoketest.js
 // Geen dependencies; test gedrag via de minimale DOM- en fetch-stub hieronder.
+// De controles zelf staan per gebied in test/checks/. Dit bestand zet de stub op,
+// draait de delen in vaste volgorde, telt de controles en rapporteert het eindresultaat.
 const fs = require("fs");
 const path = require("path");
 
@@ -59,135 +61,61 @@ global.document = { getElementById: id => byIdMap[id], createElement: tag => mak
 global.getComputedStyle = () => ({ getPropertyValue: () => "#1e5aa8" });
 global.window = global;
 
+// De delen draaien in deze volgorde; de controles bouwen op elkaars toestand voort.
+const delen = [
+  ["release-badge", require("./checks/release-badge")],
+  ["begrippen", require("./checks/begrippen")],
+  ["omgevingen", require("./checks/omgevingen")],
+  ["kaart", require("./checks/kaart")],
+  ["acties", require("./checks/acties")],
+  ["handboek", require("./checks/handboek")],
+];
+
 (async () => {
   eval(js);
   const flush = () => new Promise(resolve => setImmediate(resolve));
+  let total = 0;
+  let failed = 0;
   const assert = (cond, msg) => {
+    total++;
     if (!cond) { console.error("FAIL: " + msg); failed++; }
     else console.log("ok  : " + msg);
   };
   const findBtn = txt => created.filter(e => e.tag === "button" && e.textContent.includes(txt)).pop();
   const mapResult = () => byIdMap["map-scroll"].innerHTML;
   const glossaryResult = () => byIdMap["begrippen-lijst"].innerHTML;
-  let failed = 0;
+  const state = () => __state();
+  const setFetchMode = mode => { fetchMode = mode; };
 
+  // Gedeelde stappen: één plek voor "wat klik je aan", zodat elk deel dezelfde route kan naspelen.
+  const stappen = {
+    opnieuw: () => byIdMap["reset"].onclick(),
+    nieuwIssue: () => byIdMap["btn-issue"].onclick(),
+    maakBranch: () => findBtn("Maak branch").onclick(),
+    commit: () => byIdMap["btn-commit"].onclick(),
+    openPR: () => findBtn("Open PR").onclick(),
+    mergeCommit: () => findBtn("Merge commit").onclick(),
+    squashMerge: () => findBtn("Squash & merge").onclick(),
+    verwijderBranch: () => findBtn("Verwijder branch").onclick(),
+    promote: () => byIdMap["btn-promote"].onclick(),
+    revert: () => byIdMap["btn-revert"].onclick(),
+    kiesRollback: index => { byIdMap["rollback-version"].value = String(index); byIdMap["rollback-version"].onchange(); },
+    rollback: () => byIdMap["btn-rollback"].onclick(),
+    // issue → branch → twee commits → PR → merge; soort is "merge" of "squash"
+    mergeRonde: soort => {
+      stappen.nieuwIssue(); stappen.maakBranch();
+      stappen.commit(); stappen.commit();
+      stappen.openPR();
+      if (soort === "squash") stappen.squashMerge(); else stappen.mergeCommit();
+    },
+  };
+
+  // Vóór de eerste await uitlezen: het deel release-badge controleert de beginwaarde van de badge.
   const initialBadge = byIdMap["release-badge-label"].textContent;
-  await flush(); await flush();
-  assert(initialBadge === "release: onbekend", "badge heeft een veilige beginwaarde vóór de fetch-response");
-  assert(byIdMap["release-badge-label"].textContent === "release: v9.9.9 +2 · abc1234", "badge toont de gestempelde versie, commits-ahead en sha");
-  assert(byIdMap["release-current-link"].textContent.includes("v9.9.9"), "badge-link toont de actieve versie");
-  assert(byIdMap["release-current-link"].href.endsWith("/v9.9.9"), "badge-link verwijst naar de actieve release");
-  assert(fetchCalls.includes("version.json"), "badge vraagt buildinformatie op via fetch");
-  assert(byIdMap["release-history"].classList.contains("release-badge") && byIdMap["release-history"].classList.contains("dev"), "badge krijgt de ontwikkelstatus in de DOM");
-  fetchMode = "fallback";
-  byIdMap["reset"].onclick(); await flush(); await flush();
-  assert(byIdMap["release-badge-label"].textContent === "release: v8.0.0 +4", "badge valt terug op GitHub-release plus compare-resultaat");
-  assert(byIdMap["release-build-note"].textContent.includes("nieuwste GitHub-release"), "fallback-note legt uit dat main nieuwer kan zijn");
-  assert(fetchCalls.some(url => url.includes("releases/latest")) && fetchCalls.some(url => url.includes("compare/")), "fallback gebruikt release- en compare-endpoint");
-  fetchMode = "version";
-  byIdMap["reset"].onclick(); await flush(); await flush();
-  assert(byIdMap["release-badge-label"].textContent.startsWith("release: v9.9.9"), "badge kan na fallback opnieuw een version-file gebruiken");
-  fetchMode = "history";
-  byIdMap["release-history"].open = true;
-  byIdMap["release-history"].dataset.historyLoaded = "false";
-  byIdMap["release-history"].ontoggle(); await flush(); await flush();
-  assert(byIdMap["release-history-list"].children.length === 2, "releasehistorie rendert alle ontvangen items");
-  const historyLink = byIdMap["release-history-list"].children[0].children[0];
-  assert(historyLink.textContent === "v9.9.8", "releasehistorie toont tagnaam");
-  assert(historyLink.href === "https://example.test/releases/v9.9.8" && historyLink.target === "_blank", "releasehistorie-item linkt naar release-notes in nieuw tabblad");
-  assert(byIdMap["release-history-list"].children[0].children[1].textContent.length > 0, "releasehistorie toont publicatiedatum");
-  fetchMode = "error";
-  byIdMap["release-history"].dataset.historyLoaded = "false";
-  byIdMap["release-history"].ontoggle(); await flush(); await flush();
-  assert(byIdMap["release-history-list"].children[0]._html.indexOf("Geen eerdere releases") >= 0, "releasehistorie toont een foutveilige lege toestand");
+  const gereedschap = { assert, flush, byIdMap, created, makeEl, fetchCalls, findBtn, mapResult, glossaryResult, state, setFetchMode, stappen, initialBadge };
 
-  assert((glossaryResult().match(/<details class="term-item"/g) || []).length === 26, "begrippenlijst rendert precies 26 termen");
-  assert(glossaryResult().includes("Voorbeeld:") && glossaryResult().includes("CI monitoring unavailable"), "elke begrippenlijst-entry bevat uitleg en voorbeeld");
-  const branchTerm = makeEl("details");
-  byIdMap["term-branch"] = branchTerm;
-  focusTerm("Branch");
-  assert(branchTerm.open === true, "focusTerm opent de gekozen glossary-entry");
-  assert(branchTerm.classList.contains("term-focus") && branchTerm.scrolled, "focusTerm markeert en scrollt naar de gekozen entry");
+  for (const [, deel] of delen) await deel(gereedschap);
 
-  assert(byIdMap["env-test"].textContent === "v0.1.0", "test start op v0.1.0");
-  assert(byIdMap["env-live"].textContent === "v0.1.0", "live start op v0.1.0");
-  assert(byIdMap["btn-promote"].disabled === true, "promote start uitgeschakeld als test gelijk is aan live");
-  assert(byIdMap["btn-revert"].disabled === true, "revert start uitgeschakeld zonder merge-head");
-  assert(mapResult().includes("🧪🚀"), "kaart toont gecombineerde test/live-vlag bij de start");
-  assert(mapResult().includes("station-hit") && mapResult().includes("v0.1.0"), "kaart toont release-station en versielabel");
-  assert(mapResult().includes('role="button"') && mapResult().includes("branch-line"), "kaart rendert klikbare branch-lijn en stations");
-  assert(mapResult().includes("branch-line-hit") && mapResult().includes("station-hit"), "kaart rendert ruime klikdoelen");
-  assert(byIdMap["legend"].innerHTML.includes("release station"), "legenda benoemt release-stations");
-
-  byIdMap["btn-issue"].onclick();
-  findBtn("Maak branch").onclick();
-  assert(byIdMap["log"].children[0].innerHTML.includes("focusTerm('Branch')"), "branch-logregel bevat een klikbare Branch-term");
-  const branchLog = byIdMap["log"].children[0];
-  assert((branchLog.innerHTML.match(/class="log-term"/g) || []).length >= 1, "logregel rendert minstens één termknop");
-  byIdMap["btn-commit"].onclick();
-  assert(byIdMap["btn-commit"].disabled === false, "commit-knop is actief op een branch");
-  byIdMap["btn-commit"].onclick();
-  assert(__state().branches[__state().active].head === __state().commits[__state().commits.length - 1].id, "branch-head volgt de laatste commit");
-  findBtn("Open PR").onclick();
-  assert(__state().prs[0].state === "open", "open PR krijgt de status open");
-  findBtn("Merge commit").onclick();
-  assert(byIdMap["env-test"].textContent === "v0.1.1", "merge zet de nieuwe release op test");
-  assert(byIdMap["env-live"].textContent === "v0.1.0", "merge wijzigt live niet automatisch");
-  assert(byIdMap["btn-promote"].disabled === false, "promote wordt actief zodra test vooruitloopt");
-  assert(mapResult().includes("v0.1.1") && mapResult().includes("release station v0.1.1"), "nieuwe release krijgt label op het juiste station");
-  assert(byIdMap["log"].children[0].innerHTML.includes("focusTerm('CI (Continuous Integration)')"), "release-logregel bevat een klikbare CI-term");
-  const releaseLogTermCounts = [...byIdMap["log"].children[0].innerHTML.matchAll(/focusTerm\('([^']+)'\)/g)].map(m => m[1]);
-  assert(new Set(releaseLogTermCounts).size === releaseLogTermCounts.length, "elk begrip staat maximaal één keer in dezelfde logregel");
-  byIdMap["btn-promote"].onclick();
-  assert(byIdMap["env-live"].textContent === "v0.1.1", "promote zet test exact naar live");
-  assert(byIdMap["btn-promote"].disabled === true, "promote schakelt uit zodra test gelijk is aan live");
-  assert(mapResult().includes("🧪🚀"), "kaart toont gecombineerde vlag na promotie");
-
-  byIdMap["btn-issue"].onclick();
-  findBtn("Maak branch").onclick();
-  byIdMap["btn-commit"].onclick();
-  byIdMap["btn-commit"].onclick();
-  findBtn("Open PR").onclick();
-  findBtn("Squash & merge").onclick();
-  assert(byIdMap["env-test"].textContent === "v0.1.2", "squash-merge maakt v0.1.2 op test");
-  assert(__state().mergeKinds.has("merge") && __state().mergeKinds.has("squash"), "simulatie registreert beide merge-vormen");
-  byIdMap["btn-revert"].onclick();
-  assert(byIdMap["env-test"].textContent === "v0.1.3", "revert maakt een nieuwe testversie");
-  assert(__state().commits.at(-1).kind === "revert", "revert voegt een nieuwe revert-commit toe");
-  assert(byIdMap["env-live"].textContent === "v0.1.1", "revert laat live ongemoeid");
-  byIdMap["btn-promote"].onclick();
-  assert(byIdMap["env-live"].textContent === "v0.1.3", "promote zet de gerepareerde versie op live");
-  byIdMap["rollback-version"].value = "1";
-  byIdMap["rollback-version"].onchange();
-  assert(mapResult().includes("terugrol naar v0.1.1"), "rollback-preview markeert het gekozen release-station");
-  byIdMap["btn-rollback"].onclick();
-  assert(byIdMap["env-live"].textContent === "v0.1.1" && byIdMap["env-test"].textContent === "v0.1.3", "rollback zet alleen live terug");
-  assert(__state().env.liveCommit !== __state().env.testCommit, "rollback houdt live en test op verschillende commits");
-  findBtn("Verwijder branch").onclick();
-
-  const initialCommitId = __state().commits.find(c => c.msg === "initiële versie").id;
-  selectStart(initialCommitId);
-  assert(byIdMap["start-label"].textContent.includes(initialCommitId.slice(0, 5)), "gekozen ouder startpunt verschijnt in de DOM");
-  byIdMap["btn-issue"].onclick();
-  findBtn("Maak branch").onclick();
-  assert(__state().branches[__state().active].head === initialCommitId, "branch vanaf ouder commit gebruikt het gekozen startpunt");
-  byIdMap["btn-issue"].onclick();
-  findBtn("Maak branch").onclick();
-  byIdMap["btn-commit"].onclick();
-  const branchHead = __state().branches[__state().active].head;
-  selectStart(branchHead);
-  byIdMap["btn-issue"].onclick();
-  findBtn("Maak branch").onclick();
-  assert(__state().branches[__state().active].head === branchHead, "branch-van-branch gebruikt de gekozen branch-head");
-  assert(byIdMap["progress"].firstElementChild.style.width === "100%", "alle 13 missies voltooid → 100%");
-
-  // ── handboek-controle: WERKWIJZE.md moet elke missie dekken ──
-  const werkwijze = fs.readFileSync(path.join(__dirname, "..", "WERKWIJZE.md"), "utf8");
-  const regelsOpAf = (werkwijze.match(/^\|.*\|\s*af\s*\|\s*$/gm) || []).length;
-  const missiesInSimulatie = byIdMap["missie-list"].children.length;
-  assert(missiesInSimulatie === regelsOpAf,
-    `WERKWIJZE.md is bijgewerkt: ${missiesInSimulatie} missies in de simulatie, ${regelsOpAf} regels op 'af' in het handboek`);
-
-  if (failed) { console.error("\n" + failed + " CHECK(S) GEFAALD"); process.exit(1); }
-  console.log("\nALLE CHECKS GESLAAGD");
+  if (failed) { console.error(`\n${failed} van ${total} CHECK(S) GEFAALD`); process.exit(1); }
+  console.log(`\nALLE ${total} CHECKS GESLAAGD`);
 })();


### PR DESCRIPTION
Fixes DCS-176

## Wat en waarom

`test/smoketest.js` was één bestand waarin iedereen zijn nieuwe controles **onderaan** toevoegde, vlak boven dezelfde slotregel. Dat is structureel de plek waar twee taken elkaar raken — deze week botsten er al twee, waardoor ze achter elkaar moesten in plaats van tegelijk.

De controles staan nu per gebied in `test/checks/`, zodat twee mensen tegelijk aan de rooktest kunnen werken zonder in hetzelfde bestand te schrijven:

| Bestand | Gebied |
|---|---|
| `test/checks/kaart.js` | stations, lijnen, versielabels en vlaggen op de kaart |
| `test/checks/omgevingen.js` | wat komt op test, wat op live, en wanneer |
| `test/checks/acties.js` | commit, PR, merge-vormen, startpunt kiezen, missievoortgang |
| `test/checks/begrippen.js` | begrippenlijst en de klikbare begrippen in het logboek |
| `test/checks/release-badge.js` | badge, fallback op GitHub en releasehistorie |
| `test/checks/handboek.js` | missies tellen tegenover de regels op `af` in `WERKWIJZE.md` |

`test/smoketest.js` blijft het startbestand: het zet de DOM- en fetch-stub op (**ongedeeld — niet gedupliceerd**), draait de delen in vaste volgorde, telt de controles en rapporteert het eindresultaat. Elk deel krijgt `assert` en de gedeelde hulpmiddelen binnen, inclusief een setje benoemde stappen (`stappen.mergeCommit()`, `stappen.promote()`, …) zodat een deel zijn eigen route kan naspelen zonder de kliksequenties te kopiëren.

Alleen `require`/`module.exports`. Geen dependencies, geen npm-pakketten, geen testframework, geen build-stap. Draaien blijft:

```
node test/smoketest.js
```

## Bewijs dat het klaar is

**Groen — `node test/smoketest.js`, exitcode 0:**

```
ok  : badge heeft een veilige beginwaarde vóór de fetch-response
...
ok  : alle 13 missies voltooid → 100%
ok  : WERKWIJZE.md is bijgewerkt: 13 missies in de simulatie, 13 regels op 'af' in het handboek

ALLE 56 CHECKS GESLAAGD
EXIT=0
```

**Rood — tijdelijk één controle in `test/checks/kaart.js` stukgemaakt** (`"release station"` → `"release stationXX"`); daarna teruggedraaid:

```
FAIL: legenda benoemt release-stations

1 van 56 CHECK(S) GEFAALD
EXIT=1
```

De foutmelding noemt de juiste controle, en de suite stopt met exitcode 1.

**Aantal én teksten ongewijzigd.** De lijst met `ok`-regels van `main` en van deze branch is gesorteerd vergeleken en is letterlijk identiek: 56 controles, dezelfde 56 teksten. Geen enkele controle toegevoegd, weggehaald of anders geformuleerd — dit is verplaatsen, niet herschrijven. De volgorde binnen elk gebied is gelijk aan die op `main` gebleven.

## Wat te checken in de preview

**Niets — en dat is correct.** Deze PR raakt alleen `test/`; `index.html` is niet aangeraakt. De preview-link toont daarom exact de huidige site. Het bewijs voor deze PR is de testuitvoer hierboven, niet de preview.

## Buiten scope gebleven

Niets aan `index.html`, `AGENTS.md`, `README.md` of `WERKWIJZE.md` — die zitten in de twee andere parallel-werken-issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)