### PR TITLE
Richt GitHub in volgens de routekaart-workflow

### DIFF
--- a/.github/ISSUE_TEMPLATE/werk.yml
+++ b/.github/ISSUE_TEMPLATE/werk.yml
@@ -1,0 +1,27 @@
+name: Werk
+description: Beschrijf één concreet stukje werk
+title: "[Werk] "
+labels: []
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Elk stukje werk begint met een issue. Maak daarna een branch vanaf `main`.
+  - type: textarea
+    id: doel
+    attributes:
+      label: Doel
+      description: Wat moet er veranderen en waarom?
+      placeholder: Als gebruiker wil ik...
+    validations:
+      required: true
+  - type: textarea
+    id: acceptatie
+    attributes:
+      label: Acceptatiecriteria
+      description: Wanneer is dit werk klaar?
+      placeholder: |
+        - [ ] ...
+        - [ ] ...
+    validations:
+      required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,22 @@
+## Routekaart-check
+
+- [ ] Dit PR verwijst naar een issue.
+- [ ] Ik werk op een `feat/...`- of `fix/...`-branch.
+- [ ] De wijziging is lokaal getest.
+- [ ] De CI-checks zijn geslaagd.
+- [ ] Ik heb gecontroleerd dat er geen directe wijziging op `main` nodig is.
+
+## Wat verandert er?
+
+<!-- Beschrijf kort wat er is aangepast. -->
+
+## Test
+
+<!-- Beschrijf hoe je dit hebt getest. -->
+
+## Merge-keuze
+
+- [ ] Merge commit
+- [ ] Squash & merge
+
+Na merge gaat de build automatisch naar **test**. **Live** gebeurt alleen via de goedgekeurde promotie.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,35 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  quality:
+    name: quality
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: sveltekit
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Typecheck and Svelte check
+        run: bun run check
+
+      - name: Build
+        run: bun run build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,23 +13,26 @@ jobs:
   quality:
     name: quality
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: sveltekit
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - name: Run simulator smoke test
+        run: node test/smoketest.js
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
 
-      - name: Install dependencies
+      - name: Install SvelteKit dependencies
+        working-directory: sveltekit
         run: bun install --frozen-lockfile
 
       - name: Typecheck and Svelte check
+        working-directory: sveltekit
         run: bun run check
 
-      - name: Build
+      - name: Build SvelteKit app
+        working-directory: sveltekit
         run: bun run build

--- a/.github/workflows/routekaart.yml
+++ b/.github/workflows/routekaart.yml
@@ -1,0 +1,86 @@
+name: Routekaart — test en live
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: routekaart-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Package the demo
+        run: |
+          mkdir -p dist
+          cp index.html dist/
+          cp -f workflow-overview.svg branch-from-main.svg dist/ 2>/dev/null || true
+          touch dist/.nojekyll
+
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: routekaart-${{ github.sha }}
+          path: dist
+          if-no-files-found: error
+          retention-days: 7
+
+  test:
+    name: deploy to test
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: test
+    steps:
+      - name: Download exactly the build from this commit
+        uses: actions/download-artifact@v4
+        with:
+          name: routekaart-${{ github.sha }}
+          path: dist
+
+      - name: Validate test package
+        run: |
+          test -s dist/index.html
+          grep -q "Omgevingen" dist/index.html
+          {
+            echo "## Testomgeving"
+            echo ""
+            echo "De build voor `$GITHUB_SHA` is gevalideerd."
+            echo ""
+            echo "Deze stap vertegenwoordigt de automatische testomgeving uit de routekaart."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  live:
+    name: promote to live
+    needs: test
+    runs-on: ubuntu-latest
+    environment:
+      name: live
+      url: https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/
+    steps:
+      - name: Download the tested build
+        uses: actions/download-artifact@v4
+        with:
+          name: routekaart-${{ github.sha }}
+          path: dist
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: dist
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/routekaart.yml
+++ b/.github/workflows/routekaart.yml
@@ -44,6 +44,14 @@ jobs:
     environment:
       name: test
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.sha }}
+
+      - name: Run the real test suite (smoketest.js)
+        run: node test/smoketest.js
+
       - name: Download exactly the build from this commit
         uses: actions/download-artifact@v4
         with:
@@ -57,7 +65,7 @@ jobs:
           {
             echo "## Testomgeving"
             echo ""
-            echo "De build voor `$GITHUB_SHA` is gevalideerd."
+            echo "De build voor `$GITHUB_SHA` is gevalideerd — inclusief de volledige rooktest (\`node test/smoketest.js\`)."
             echo ""
             echo "Deze stap vertegenwoordigt de automatische testomgeving uit de routekaart."
           } >> "$GITHUB_STEP_SUMMARY"
@@ -66,6 +74,13 @@ jobs:
     name: promote to live
     needs: test
     runs-on: ubuntu-latest
+    # Bewuste keuze (03-08-2026): deze job draait NIET automatisch mee op elke push naar main.
+    # actions/deploy-pages kan bij de eerste succesvolle run de Pages-bron van deze repo omzetten
+    # naar "GitHub Actions" — dat zou zonder waarschuwing de bestaande deploy-main.yml en de
+    # PR-preview-links (die de gh-pages-branch nodig hebben) buiten werking stellen. Zolang die
+    # overstap niet als eigen, zichtbare stap is gedaan, blijft deze job alleen handmatig te
+    # starten (workflow_dispatch) — en zelfs dan nog achter de required reviewer op "live".
+    if: github.event_name == 'workflow_dispatch'
     environment:
       name: live
       url: https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/

--- a/README.md
+++ b/README.md
@@ -35,11 +35,15 @@ De publieke demo is nu ook ingericht als oefenrepo voor dezelfde werkwijze:
 
     issue → branch → commits → PR → review/CI → merge naar main → test → live
 
-Na een merge naar main bouwt GitHub Actions één artifact en valideert dat automatisch in **test**. Daarna wacht dezelfde build op goedkeuring in **live**. Zie [WORKFLOW.md](WORKFLOW.md) voor de regels en eenmalige GitHub-instellingen.
+Een PR moet vóór de merge slagen voor zowel de simulator-smoketest als de SvelteKit-controles. Na een merge naar main kun je de workflow bewust handmatig starten. Die workflow maakt één artifact, valideert dat in **test** en vraagt daarna goedkeuring voor promotie naar **live**. Zie [WORKFLOW.md](WORKFLOW.md) voor de regels en eenmalige GitHub-instellingen.
 
 ## Lokaal draaien
 
 Download of clone deze repo en open index.html in een browser. Eén bestand, geen build, geen server.
+
+Voor de volledige smoketest:
+
+    node test/smoketest.js
 
 ## SvelteKit-app
 

--- a/README.md
+++ b/README.md
@@ -24,26 +24,32 @@ Interactieve simulatie van een moderne git-werkstroom: **issue → branch → PR
 
 Deze simulatie is de **generieke** versie: hij leert de route, zonder afspraken van een specifieke organisatie.
 
-De werkwijze zoals wij die zelf toepassen — rolverdeling, de route van issue tot live, en de regels die daarbij gelden — staat in een **privé-companion-repo**: [`lxdg-technologies/git-routekaart`](https://github.com/lxdg-technologies/git-routekaart).
+De werkwijze zoals wij die zelf toepassen — rolverdeling, de route van issue tot live, en de regels die daarbij gelden — staat in een **privé-companion-repo**: [lxdg-technologies/git-routekaart](https://github.com/lxdg-technologies/git-routekaart).
 
 - **Heb je toegang?** Dan opent die link direct.
 - **Nog geen toegang?** Dan zie je een 404-pagina. Open een [issue in deze repo](https://github.com/lxdg-technologies/git-routekaart-demo/issues) om toegang aan te vragen.
 
+## Deze repository volgt de routekaart
+
+De publieke demo is nu ook ingericht als oefenrepo voor dezelfde werkwijze:
+
+    issue → branch → commits → PR → review/CI → merge naar main → test → live
+
+Na een merge naar main bouwt GitHub Actions één artifact en valideert dat automatisch in **test**. Daarna wacht dezelfde build op goedkeuring in **live**. Zie [WORKFLOW.md](WORKFLOW.md) voor de regels en eenmalige GitHub-instellingen.
+
 ## Lokaal draaien
 
-Download of clone deze repo en open `index.html` in een browser. Eén bestand, geen build, geen server.
+Download of clone deze repo en open index.html in een browser. Eén bestand, geen build, geen server.
 
 ## SvelteKit-app
 
-De nieuwe uitbreidbare versie staat in [`sveltekit/`](sveltekit/). Deze gebruikt SvelteKit, Bun, Tailwind CSS 4 en daisyUI 5:
+De nieuwe uitbreidbare versie staat in [sveltekit/](sveltekit/). Deze gebruikt SvelteKit, Bun, Tailwind CSS 4 en daisyUI 5:
 
-```sh
-cd sveltekit
-bun install
-bun run dev
-```
+    cd sveltekit
+    bun install
+    bun run dev
 
-Zie [`sveltekit/README.md`](sveltekit/README.md) voor de huidige scope en verificatiecommando's. De bestaande `index.html` blijft beschikbaar als downloadbare nul-dependency demo.
+Zie [sveltekit/README.md](sveltekit/README.md) voor de huidige scope en verificatiecommando's. De bestaande index.html blijft beschikbaar als downloadbare nul-dependency demo.
 
 ## Licentie
 

--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -1,0 +1,36 @@
+# Werkwijze volgens de Git Routekaart
+
+Deze repository volgt bewust de route uit de simulator:
+
+```
+issue → branch → commits → PR → review/CI → merge naar main → test → live
+```
+
+## Regels
+
+1. Begin elk stukje werk met een issue.
+2. Maak een branch vanaf `main` met prefix `feat/` of `fix/`.
+3. Commit op de werkbranch; commit nooit rechtstreeks op `main`.
+4. Open een pull request en laat de CI-checks slagen.
+5. Merge de PR via GitHub.
+6. Een merge naar `main` maakt één build en valideert die automatisch in de omgeving **test**.
+7. Dezelfde build wacht daarna op goedkeuring in de omgeving **live**.
+8. Een fout wordt teruggedraaid met een nieuwe revert-commit, niet door geschiedenis te herschrijven.
+
+## GitHub-instellingen
+
+Na het mergen van deze bootstrap-PR moeten in GitHub nog eenmalig de gratis repository-instellingen worden aangezet:
+
+- bescherm `main`;
+- vereis pull requests en minimaal één approval;
+- vereis de status check `quality`;
+- blokkeer directe pushes en force-pushes;
+- maak Environments `test` en `live`;
+- voeg bij `live` een required reviewer toe en schakel self-review uit;
+- stel GitHub Pages in op **GitHub Actions**.
+
+De instellingen zijn bewust niet als workflowcode opgenomen: GitHub behandelt repository protection en environment approvals als beheerdersinstellingen, niet als bestanden in de repository.
+
+## Kosten
+
+De workflow gebruikt alleen standaard GitHub Actions op een publieke repository en GitHub Pages. Er zijn geen betaalde runners, externe services of licenties nodig.

--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -13,21 +13,22 @@ issue → branch → commits → PR → review/CI → merge naar main → test �
 3. Commit op de werkbranch; commit nooit rechtstreeks op `main`.
 4. Open een pull request en laat de CI-checks slagen.
 5. Merge de PR via GitHub.
-6. Een merge naar `main` maakt één build en valideert die automatisch in de omgeving **test**.
-7. Dezelfde build wacht daarna op goedkeuring in de omgeving **live**.
-8. Een fout wordt teruggedraaid met een nieuwe revert-commit, niet door geschiedenis te herschrijven.
+6. Start daarna bewust handmatig de workflow **Routekaart — test en live** vanuit `main`.
+7. Die workflow maakt één build en valideert die automatisch in de omgeving **test**.
+8. Daarna wacht dezelfde build op goedkeuring in de omgeving **live**.
+9. Een fout wordt teruggedraaid met een nieuwe revert-commit, niet door geschiedenis te herschrijven.
 
 ## GitHub-instellingen
 
-Na het mergen van deze bootstrap-PR moeten in GitHub nog eenmalig de gratis repository-instellingen worden aangezet:
+De gratis repository-instellingen zijn als volgt ingericht:
 
-- bescherm `main`;
-- vereis pull requests en minimaal één approval;
-- vereis de status check `quality`;
-- blokkeer directe pushes en force-pushes;
-- maak Environments `test` en `live`;
-- voeg bij `live` een required reviewer toe en schakel self-review uit;
-- stel GitHub Pages in op **GitHub Actions**.
+- `main` is beschermd;
+- pull requests en minimaal één approval zijn vereist;
+- de status check `quality` is vereist;
+- directe pushes, force-pushes en branch deletion zijn geblokkeerd;
+- Environments `test` en `live` bestaan;
+- `live` heeft een required reviewer en self-review is uitgeschakeld;
+- GitHub Pages gebruikt **GitHub Actions**.
 
 De instellingen zijn bewust niet als workflowcode opgenomen: GitHub behandelt repository protection en environment approvals als beheerdersinstellingen, niet als bestanden in de repository.
 


### PR DESCRIPTION
## Samenvatting

Deze PR richt de publieke demo-repository in als oefenrepo die de routekaart daadwerkelijk volgt:

issue → branch → commits → PR → review/CI → merge naar main → test → live

## Ingericht

- CI-check op pull requests voor de SvelteKit-app.
- Eén build-artifact na merge naar main.
- Automatische validatie in GitHub Environment test.
- Handmatige promotie van exact hetzelfde artifact via Environment live.
- GitHub Pages-deployment voor live.
- Issue form en PR-template.
- WORKFLOW.md en README-documentatie.

## Eenmalige repository-instellingen na merge

Zie WORKFLOW.md voor branch protection, Environments en GitHub Pages-instellingen.