### PR TITLE
ci: voeg quality rooktest toe

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -1,0 +1,23 @@
+# Deze controle draait de rooktest, zodat kapotte wijzigingen niet kunnen worden gemerged.
+name: Quality
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+jobs:
+  quality:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Node.js 20 instellen
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Rooktest draaien
+        run: node test/smoketest.js


### PR DESCRIPTION
## Samenvatting
- Voegt de ontbrekende verplichte statuscheck `quality` toe.
- Laat de workflow de nul-dependency rooktest draaien op Node.js 20.
- Triggert op pull requests naar `main` en pushes naar `main`.

## Test
- `node test/smoketest.js` — 63/63 checks groen op `main`.

## Wat te checken in de preview
Niets — deze PR wijzigt alleen een workflow, dus de preview toont precies dezelfde site als nu.

Closes #32
