### PR TITLE
fix: gh-pages-publicaties racen niet meer met elkaar

### DIFF
--- a/.github/workflows/deploy-main.yml
+++ b/.github/workflows/deploy-main.yml
@@ -8,8 +8,8 @@ permissions:
   contents: write
 
 concurrency:
-  group: pages-main
-  cancel-in-progress: true
+  group: gh-pages-publish
+  cancel-in-progress: false
 
 jobs:
   deploy:
@@ -38,5 +38,20 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add -A -- index.html README.md LICENSE
-          git diff --cached --quiet && echo "Geen wijziging" || git commit -m "Deploy production van main@${GITHUB_SHA::7}"
-          git push
+          if git diff --cached --quiet; then
+            echo "Geen wijziging"
+            exit 0
+          fi
+          git commit -m "Deploy production van main@${GITHUB_SHA::7}"
+          for i in 1 2 3 4 5; do
+            if git push; then
+              echo "Gepusht"
+              exit 0
+            fi
+            echo "Push afgewezen (poging $i) — gh-pages is intussen bijgewerkt, opnieuw proberen"
+            git fetch origin gh-pages
+            git rebase origin/gh-pages
+            sleep 3
+          done
+          echo "::error::Push naar gh-pages bleef mislukken na 5 pogingen"
+          exit 1

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -9,8 +9,8 @@ permissions:
   pull-requests: write
 
 concurrency:
-  group: pr-preview-${{ github.event.number }}
-  cancel-in-progress: true
+  group: gh-pages-publish
+  cancel-in-progress: false
 
 jobs:
   preview:


### PR DESCRIPTION
## Oorzaak

Na het mergen van PR #36 mislukte `Deploy production site to gh-pages` met:

```
! [rejected] gh-pages -> gh-pages (fetch first)
```

`deploy-main.yml` (pusht de productie-inhoud naar `gh-pages`) en `pr-preview.yml`
(pusht/verwijdert PR-previews op diezelfde branch, ook bij het sluiten van een PR)
hadden **elk hun eigen concurrency-groep**. Een merge sluit de PR meteen, dus
het "verwijder de preview"-onderdeel van `pr-preview.yml` en de productie-sync
van `deploy-main.yml` draaiden tegelijk tegen dezelfde `gh-pages`-branch —
klassieke race condition, geen inhoudelijke fout.

De Pages-bron zelf staat nog gewoon op "Deploy from branch: gh-pages" (`legacy`),
niet omgezet naar "GitHub Actions" — dat afzonderlijke risico (uit de review van
PR #28) speelt hier dus niet mee.

## Wat is gewijzigd

- `.github/workflows/deploy-main.yml` en `.github/workflows/pr-preview.yml`
  delen nu **dezelfde concurrency-groep** (`gh-pages-publish`), met
  `cancel-in-progress: false` — runs wachten netjes op elkaar in plaats van
  tegelijk naar dezelfde branch te schrijven.
- `deploy-main.yml` probeert de push bij afwijzing tot 5x opnieuw
  (`git fetch` + `git rebase` + korte pauze) als extra vangnet.
- Geen wijziging aan `index.html` of ander applicatiegedrag.

## Waarom dit veilig is

- Alleen concurrency-instellingen en een retry-loop op een bestaande stap —
  geen nieuwe rechten, geen wijziging aan wat er gepubliceerd wordt.
- `cancel-in-progress: false` voorkomt dat een lopende publicatie halverwege
  wordt afgebroken door een andere trigger.
- Geen wijziging aan de Pages-bron-instelling.

## Gecontroleerd

- `node test/smoketest.js` lokaal ongewijzigd relevant (geen `index.html`-wijziging).
- CI (`quality`, `preview`) moet hier vanzelf op groen komen te staan.
- Na merge: de eerstvolgende push naar `main` (of het opnieuw draaien van de
  huidige mislukte run) moet zonder "rejected" doorgaan.

Niet gemergd, niet force-gepusht. Merge doet Rob.