### PR TITLE
fix: voorkom dat gh-pages als Jekyll-site gebouwd wordt

### DIFF
--- a/.github/workflows/deploy-main.yml
+++ b/.github/workflows/deploy-main.yml
@@ -31,13 +31,14 @@ jobs:
           cp main/index.html gh-pages/index.html
           cp main/README.md gh-pages/README.md
           cp main/LICENSE gh-pages/LICENSE
+          touch gh-pages/.nojekyll
 
       - name: Commit and push if changed
         working-directory: gh-pages
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add -A -- index.html README.md LICENSE
+          git add -A -- index.html README.md LICENSE .nojekyll
           if git diff --cached --quiet; then
             echo "Geen wijziging"
             exit 0


### PR DESCRIPTION
## Oorzaak

Ook na de racefix (#37) toonde de live site de nieuwe inhoud niet. `gh-pages` bevatte
de juiste bestanden, maar GitHub's Pages-build faalde stil (\"Page build failed\",
zonder verdere details via de API) — dit gebeurde al sinds 3 augustus, niet pas vandaag.

Reden: dit project publiceert via de klassieke branch-methode ("Deploy from branch"),
die standaard **Jekyll** gebruikt om de site te bouwen, tenzij er een `.nojekyll`-bestand
in de root van `gh-pages` staat. Dat bestand ontbrak volledig — GitHub probeerde dus
telkens de site door Jekyll te laten verwerken, wat bij deze inhoud soms lukte en soms
niet (afhankelijk van wat er op dat moment in `pr-preview/*` stond).

## Wat is gewijzigd

- `.nojekyll` direct op `gh-pages` gezet (los, buiten deze PR om, zodat de site nu al
  klopt zonder op een merge te wachten).
- `deploy-main.yml`: de sync-stap maakt voortaan altijd `.nojekyll` opnieuw aan en
  neemt het mee in de commit, zodat het nooit meer stil kan verdwijnen.

## Waarom dit veilig is

- `.nojekyll` is een leeg, standaard GitHub Pages-signaalbestand — geen effect op de
  inhoud, alleen op hóe GitHub 'm publiceert.
- Geen wijziging aan applicatiegedrag, geen nieuwe rechten.

## Gecontroleerd

- CI (`quality`, `preview`) moet hier vanzelf op groen komen.
- De live site toont de commandoreferentie al, sinds het losse `.nojekyll`-commit op
  `gh-pages` — deze PR zorgt dat dat zo blijft bij de volgende publicatie.

Niet gemergd, niet force-gepusht.