### PR TITLE
Ontwikkelomgeving per pull request op /dev/pr-N/

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -15,6 +15,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
 
 concurrency:
   group: gh-pages-environments
@@ -83,6 +84,23 @@ jobs:
           done
           echo "::error::Publiceren naar gh-pages bleef mislukken na 5 pogingen"
           exit 1
+
+      # GitHub toont de omgeving zelf al onder "View deployment", maar dat is weggestopt en
+      # het woord zegt een niet-technische beoordelaar niets. Eén gewone regel met een
+      # klikbaar adres, alleen bij het openen van de pull request zodat het geen spam wordt.
+      - name: Zet het adres van de ontwikkelomgeving in de pull request
+        if: github.event.action == 'opened' || github.event.action == 'reopened'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          gh pr comment "${{ github.event.number }}" --repo "${{ github.repository }}" --body \
+          "🔧 **Ontwikkelomgeving van deze pull request**
+
+          https://lxdg-technologies.github.io/git-routekaart-demo/dev/pr-${{ github.event.number }}/
+
+          Hier zie je deze wijziging draaien zonder dat test of de echte site iets merkt. Het adres wordt bijgewerkt bij elke nieuwe commit en verdwijnt zodra deze pull request sluit."
 
   cleanup-dev:
     if: github.event.action == 'closed'

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -1,0 +1,125 @@
+name: Deploy pull request to development
+
+# Elke openstaande pull request krijgt zijn eigen ontwikkelomgeving op /dev/pr-<nummer>/.
+# Dat is de echte tegenhanger van "Ontwikkel" uit de routekaart: jouw branch, jouw plek,
+# fouten raken niemand anders. Test en productie worden hier nooit aangeraakt.
+#
+# Bewust `pull_request` en niet `pull_request_target`: dit is een publieke repository, dus
+# iedereen kan een pull request openen. Bij `pull_request` krijgt een fork een leestoken,
+# waardoor de publicatiestap onschuldig faalt in plaats van vreemde code met schrijfrechten
+# uit te voeren. Deze keuze niet omdraaien.
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, closed]
+
+permissions:
+  contents: write
+
+concurrency:
+  group: gh-pages-environments
+  cancel-in-progress: false
+
+jobs:
+  deploy-dev:
+    if: github.event.action != 'closed'
+    runs-on: ubuntu-latest
+    environment:
+      name: development
+      url: https://lxdg-technologies.github.io/git-routekaart-demo/dev/pr-${{ github.event.number }}/
+    steps:
+      - name: Checkout de pull request
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          path: source
+
+      - name: Checkout deployment branch
+        uses: actions/checkout@v6
+        with:
+          ref: gh-pages
+          path: site
+
+      - name: Vervang alleen de ontwikkelomgeving van deze pull request
+        shell: bash
+        run: |
+          set -euo pipefail
+          git -C site rm -r --ignore-unmatch "dev/pr-${{ github.event.number }}"
+          mkdir -p "site/dev/pr-${{ github.event.number }}"
+          cp source/index.html "site/dev/pr-${{ github.event.number }}/index.html"
+          cp source/README.md "site/dev/pr-${{ github.event.number }}/README.md"
+          cp source/LICENSE "site/dev/pr-${{ github.event.number }}/LICENSE"
+          printf '{"environment":"development","pull_request":%s,"branch":"%s","sha":"%s"}\n' \
+            "${{ github.event.number }}" \
+            "${{ github.event.pull_request.head.ref }}" \
+            "${{ github.event.pull_request.head.sha }}" \
+            > "site/dev/pr-${{ github.event.number }}/environment.json"
+
+      - name: Publiceer de ontwikkelomgeving
+        working-directory: site
+        shell: bash
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add -A -- "dev/pr-${{ github.event.number }}"
+          if git diff --cached --quiet; then
+            echo "Ontwikkelomgeving is al actueel"
+            exit 0
+          fi
+          git commit -m "Deploy dev voor PR #${{ github.event.number }} (${GITHUB_SHA::7})"
+          # Opnieuw proberen als een andere omgevingsdeploy net voor was. De concurrency-groep
+          # vangt het meeste af, maar bij meerdere openstaande pull requests kan een wachtende
+          # run alsnog vervangen worden; deze lus voorkomt dat een deploy stilzwijgend verdwijnt.
+          for poging in 1 2 3 4 5; do
+            if git push origin gh-pages; then
+              echo "Gepubliceerd"
+              exit 0
+            fi
+            echo "Push afgewezen (poging $poging) — deploymentbranch is intussen bijgewerkt"
+            git fetch origin gh-pages
+            git rebase origin/gh-pages
+            sleep 3
+          done
+          echo "::error::Publiceren naar gh-pages bleef mislukken na 5 pogingen"
+          exit 1
+
+  cleanup-dev:
+    if: github.event.action == 'closed'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout deployment branch
+        uses: actions/checkout@v6
+        with:
+          ref: gh-pages
+          path: site
+
+      - name: Ruim de ontwikkelomgeving van deze pull request op
+        working-directory: site
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ ! -d "dev/pr-${{ github.event.number }}" ]; then
+            echo "Niets op te ruimen"
+            exit 0
+          fi
+          git rm -r --ignore-unmatch "dev/pr-${{ github.event.number }}"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add -A -- "dev/pr-${{ github.event.number }}"
+          if git diff --cached --quiet; then
+            echo "Niets op te ruimen"
+            exit 0
+          fi
+          git commit -m "Ruim dev op voor gesloten PR #${{ github.event.number }}"
+          for poging in 1 2 3 4 5; do
+            if git push origin gh-pages; then
+              echo "Opgeruimd"
+              exit 0
+            fi
+            git fetch origin gh-pages
+            git rebase origin/gh-pages
+            sleep 3
+          done
+          echo "::error::Opruimen van gh-pages bleef mislukken na 5 pogingen"
+          exit 1

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,7 +72,7 @@ Squash-gedrag op de kaart: gesquashte commits krijgen `c.squashed = true` en wor
 1. Branch vanaf `main` (`feat/...` of `fix/...`) — nooit direct op `main` committen.
 2. Pas `index.html` aan; werk zo nodig `test/smoketest.js` mee bij.
 3. **Draai `node test/smoketest.js` — moet 100% groen zijn** vóór je de PR als klaar beschouwt. Voeg voor nieuw gedrag nieuwe asserts toe. **Een nieuwe assert controleert gedrag of een uiteindelijk DOM-resultaat, nooit de letterlijke inhoud van het `<script>`-blok.**
-4. Open een PR met een duidelijke omschrijving in gewone taal (de reviewer is niet altijd technisch). **Elke PR die de simulatie zelf verandert (dus niet alleen CI/docs) krijgt een expliciete "wat lokaal te checken"-regel**, bijv. "Open `index.html`, klik X aan en kijk of Y verschijnt". Deze omgevingsroute publiceert bewust geen PR-preview op `gh-pages`, omdat alleen test en productie die deploymentbranch mogen wijzigen.
+4. Open een PR met een duidelijke omschrijving in gewone taal (de reviewer is niet altijd technisch). **Elke PR die de simulatie zelf verandert (dus niet alleen CI/docs) krijgt een expliciete "wat te checken"-regel**, bijv. "Klik X aan en kijk of Y verschijnt". De beoordelaar kijkt in de ontwikkelomgeving van die pull request: `https://lxdg-technologies.github.io/git-routekaart-demo/dev/pr-<nummer>/`. Zonder zo'n regel is dat adres net zo nietszeggend als geen adres — het toont dát er iets is, niet wát.
 5. **Mergen doet een mens** (repo-eigenaar beslist) — een agent merget nooit zelf. Een merge naar `main` vernieuwt test; productie vereist daarna nog een afzonderlijke handmatige promotie.
 
 ## Met meerdere mensen tegelijk werken
@@ -94,11 +94,19 @@ Squash-gedrag op de kaart: gesquashte commits krijgen `c.squashed = true` en wor
 
 ## Omgevingsdeployments
 
-`.github/workflows/deploy-test.yml` draait na een push naar `main` en vervangt alleen de map
-`/test/` op de deploymentbranch:
+Deze repository heeft drie echte omgevingen, met dezelfde namen en regels als op de kaart:
 
-- `main` → test op `/test/`
-- handmatige `.github/workflows/promote-production.yml` → productie op `/`
+- openstaande pull request → **ontwikkel** op `/dev/pr-<nummer>/` (`.github/workflows/deploy-dev.yml`)
+- `main` → **test** op `/test/` (`.github/workflows/deploy-test.yml`)
+- handmatige `.github/workflows/promote-production.yml` → **productie** op `/`
+
+Elke workflow raakt uitsluitend zijn eigen map aan. De ontwikkelomgeving wordt bijgewerkt bij
+elke push naar de pull request en automatisch opgeruimd zodra die sluit.
+
+`deploy-dev.yml` gebruikt bewust `pull_request` en **niet** `pull_request_target`: dit is een
+publieke repository, dus iedereen kan een pull request openen. Bij `pull_request` krijgt een
+fork een leestoken en faalt de publicatiestap onschuldig, in plaats van vreemde code met
+schrijfrechten uit te voeren. Draai die keuze niet om.
 
 De promotieworkflow leest de commit-SHA uit `test/environment.json` en kopieert exact die
 bestanden naar productie. Beide jobs verwijzen naar de echte GitHub Environments `test` en

--- a/WERKWIJZE.md
+++ b/WERKWIJZE.md
@@ -32,6 +32,16 @@ Boven de simulatie staat een read-only venster op deze echte publieke repository
 
 **Twee stappen zitten er in het echt tussen, maar niet in de simulatie:** de automatische controles die een pull request tegenhouden als er iets stuk is, en de beoordeling door een mens die goedkeurt of wijzigingen vraagt. Allebei bewust weggelaten — zie hoofdstuk 5.
 
+**Deze repository doet inmiddels zelf precies wat hij voordoet.** Sinds 07-08-2026 heeft hij drie echte omgevingen, met dezelfde namen en dezelfde regels als op de kaart:
+
+| Omgeving op de kaart | In deze repository | Wanneer verandert die |
+|---|---|---|
+| Ontwikkel | `/dev/pr-<nummer>/` | Zodra je een pull request opent of bijwerkt — elke pull request heeft zijn eigen plek |
+| Test | `/test/` | Automatisch bij elke merge naar `main` |
+| Live | de hoofdpagina | Alleen door een handmatig gestarte promotie van exact de geteste versie |
+
+Daarvóór stond elke merge binnen een minuut rechtstreeks live — precies wat de simulatie afraadt. Wie wil zien hoe dit in het echt werkt, hoeft dus niet verder te kijken dan deze repository zelf. De technische uitvoering staat in `DEPLOYMENT.md`.
+
 ## 3. De eindstreep
 
 **v1 is af** als iemand na één keer doorlopen, zonder hulp:
@@ -75,9 +85,9 @@ Dit is geen achterstand. Dit zijn keuzes, met datum. Constateer je een van deze 
 | Wat ontbreekt | Waarom bewust | Besloten |
 |---|---|---|
 | Een tweede persoon die ook mergt | v1 leert de keten, niet het samenwerken. Zonder tweede hand beweegt de hoofdlijn nooit onder je voeten — dat hoort bij v2 | 03-08-2026 |
-| Een review-poort (goedkeuren / wijzigingen vragen) | Hoort niet in een nagespeelde omgeving thuis maar in de instellingen van een echte repo, waar hij echt tegenhoudt | 03-08-2026 |
+| Een review-poort (goedkeuren / wijzigingen vragen) | Hoort niet in een nagespeelde omgeving thuis maar in de instellingen van een echte repo, waar hij echt tegenhoudt. **Sinds 07-08-2026 is dat in deze repository ook echt zo geregeld: `main` eist een pull request met goedkeuring** | 03-08-2026 |
 | Merge-conflicten | Het enige dat samenwerken spannend maakt, en juist daarom slecht na te spelen met knopjes. Kandidaat voor v2. De werkwijze eromheen staat wél vast (zie `AGENTS.md`), alleen de simulatie speelt het niet na | 03-08-2026 |
-| Een controle die een merge tegenhoudt | Zelfde reden als de review-poort: echt of niet | 03-08-2026 |
+| Een controle die een merge tegenhoudt | Zelfde reden als de review-poort: echt of niet. **Sinds 05-08-2026 houdt de verplichte controle `quality` een merge in deze repository daadwerkelijk tegen** | 03-08-2026 |
 | Een kapotte live-omgeving | Rollback kun je nu oefenen zonder ooit paniek te voelen. Kandidaat voor v2 | 03-08-2026 |
 | Semver-nuance (major/minor) | Versienummers zijn bewust simpel (`v0.1.n`); versiebeleid is hier geen leerdoel | 29-07-2026 |
 
@@ -100,6 +110,8 @@ Wat dat wél doet: voorkomen dat er ongemerkt iets binnenkomt. Wat het níet doe
 
 Nieuwste bovenaan. Eén regel per besluit, altijd met datum.
 
+- **07-08-2026** — Elke openstaande pull request krijgt een eigen ontwikkelomgeving op `/dev/pr-<nummer>/`. Daarmee heeft de repository dezelfde drie omgevingen als de kaart, en is er weer een moment om een wijziging te bekijken vóórdat hij op `main` staat — wat verdween toen de oude PR-previews vervielen. Bewust "ontwikkelomgeving" genoemd en niet "preview", zodat kaart en werkelijkheid dezelfde woorden gebruiken. Bewust één plek per pull request, omdat de kaart leert dat Ontwikkel van jou alleen is.
+- **07-08-2026** — De repository publiceert niet langer rechtstreeks naar live bij elke merge. Merge gaat naar test; live verandert alleen door een handmatige promotie van exact de geteste versie. Daarmee stopt de tegenstrijdigheid dat het leermiddel iets afraadde wat het zelf deed.
 - **07-08-2026** — Een read-only dashboard met echte publieke repositorygegevens staat boven de simulatie. Het vormt de brug van oefenen naar herkennen, verandert geen GitHub-data en voegt geen missie toe.
 - **05-08-2026** — Een open pull request is nu ook op de kaart te zien: een gestippelde, nog niet aangesloten lijn vanaf de kop van de branch richting main. Geen nieuwe missie; het maakt missie 4 zichtbaar.
 - **03-08-2026** — Het omgevingsfilter maakt de actieve omgeving zichtbaar met een kader en Ontwikkel toont alleen het werk-in-uitvoering plus het vertrekpunt; bordjes worden tegen de werkelijke lijnbochten geplaatst.


### PR DESCRIPTION
Uitwerking van Kevins voorstel: elke openstaande pull request krijgt zijn eigen
ontwikkelomgeving, zodat er weer een moment is om een wijziging te bekijken **vóórdat**
hij op `main` staat. Dat moment verdween toen de oude PR-previews vervielen.

## Waarom per pull request en niet één gedeelde /dev/

De kaart leert: *"Ontwikkel = jouw branch, jouw machine — fouten raken hier niemand."*
Eén gedeelde ontwikkelomgeving spreekt dat tegen, want dan overschrijven twee pull requests
elkaar. Een eigen map per pull request is de letterlijke vertaling daarvan, en meerdere
wijzigingen kunnen tegelijk beoordeeld worden.

Daarmee heeft deze repository dezelfde drie omgevingen als de kaart:

| Op de kaart | Hier | Verandert wanneer |
|---|---|---|
| Ontwikkel | `/dev/pr-<nummer>/` | Bij openen of bijwerken van een pull request |
| Test | `/test/` | Automatisch bij elke merge naar `main` |
| Live | de hoofdpagina | Alleen door een handmatige promotie van exact de geteste versie |

## Wat er is gewijzigd

- **`.github/workflows/deploy-dev.yml`** (nieuw) — publiceert de pull request naar
  `/dev/pr-<nummer>/` en ruimt die map automatisch op zodra de pull request sluit.
- **`WERKWIJZE.md`** — de drie omgevingen beschreven in hoofdstuk 2; twee regels in
  hoofdstuk 5 aangevuld die inmiddels écht waargemaakt zijn (de review-poort en de
  blokkerende controle bestaan nu in de repo-instellingen); twee besluiten toegevoegd.
- **`AGENTS.md`** — de passage die zegt dat er bewust géén ontwikkelomgeving is, vervangen
  door hoe hij nu werkt. De "wat te checken"-regel per PR verwijst weer naar een adres.

Geen wijziging aan `index.html` of aan test/productie.

## Twee bewuste keuzes

**`pull_request`, niet `pull_request_target`.** Dit is een publieke repository, dus iedereen
kan een pull request openen. Bij `pull_request` krijgt een fork een leestoken en faalt de
publicatiestap onschuldig; `pull_request_target` zou vreemde code met schrijfrechten
uitvoeren. Staat ook als waarschuwing in de workflow en in `AGENTS.md`.

**Zelfde concurrency-groep als test en productie** (`gh-pages-environments`), plus een
herhaalpoging bij een afgewezen push. Op 06-08 liep de publicatie vast doordat twee
workflows tegelijk naar `gh-pages` schreven; deze workflow schrijft naar dezelfde branch en
mag dat niet opnieuw veroorzaken.

## Wat te checken

Deze pull request verandert de simulatie zelf niet, dus zijn eigen ontwikkelomgeving toont
hetzelfde als nu. De echte proef is de eerstvolgende pull request die `index.html` aanraakt —
issue #45 staat daarvoor klaar. Verwacht: `/dev/pr-<nummer>/` toont die wijziging, `/test/`
en de hoofdpagina blijven onveranderd.