### PR TITLE
Toon in ontwikkel en test welke omgeving en versie je bekijkt

### DIFF
--- a/.github/scripts/omgevingsbalk.sh
+++ b/.github/scripts/omgevingsbalk.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# Zet een balk bovenaan een gepubliceerde kopie van de simulatie, zodat meteen zichtbaar is
+# wélke omgeving je bekijkt en wélke versie daarin staat.
+#
+# Waarom: tussen "de workflow is groen" en "de pagina toont de nieuwe versie" zit ongeveer
+# een minuut publiceertijd. Wie te vroeg kijkt, beoordeelt zonder het te merken de vorige
+# versie. Met het commitnummer in beeld is dat meteen te zien, zonder dat iemand een
+# waarschuwing hoeft te onthouden. Bijkomend: een ontwikkel- of testversie kan niet meer
+# per ongeluk voor de echte site worden aangezien.
+#
+# De balk wordt alleen aan de gepubliceerde kopie toegevoegd, nooit aan index.html in de
+# repository. Productie krijgt hem bewust niet — daar hoort geen ruis.
+#
+# Gebruik: omgevingsbalk.sh <bestand> <omgeving> <label> <commit-sha>
+#   omgeving : development | test
+#   label    : vrije tekst, bijv. "pull request #49" of "main"
+
+set -euo pipefail
+
+bestand="$1"
+omgeving="$2"
+label="$3"
+sha="$4"
+kort="${sha:0:7}"
+
+case "$omgeving" in
+  development) titel="Ontwikkelversie"; kleur="var(--warn)" ;;
+  test)        titel="Testversie";      kleur="var(--accent)" ;;
+  *) echo "Onbekende omgeving: $omgeving" >&2; exit 1 ;;
+esac
+
+balk=$(cat <<EOF
+<div role="note" style="
+  background:${kleur};
+  color:#fff;
+  font:600 14px/1.5 system-ui,-apple-system,'Segoe UI',sans-serif;
+  padding:.55rem 1rem;
+  text-align:center;
+  letter-spacing:.01em;">
+  ${titel} — ${label} · versie <code style="font:inherit;font-weight:700;">${kort}</code>
+  <span style="display:block;font-weight:400;opacity:.9;">
+    Dit is niet de echte site. Klopt dit versienummer niet met wat je verwacht, dan is het
+    publiceren nog bezig — wacht een minuut en ververs de pagina.
+  </span>
+</div>
+EOF
+)
+
+# Direct na <body> invoegen. Eén keer, en alleen als hij er nog niet staat.
+if grep -q 'role="note"' "$bestand"; then
+  echo "Balk staat er al, niets gedaan"
+  exit 0
+fi
+
+tijdelijk="$(mktemp)"
+awk -v balk="$balk" '
+  { print }
+  !gedaan && /<body>/ { print balk; gedaan = 1 }
+' "$bestand" > "$tijdelijk"
+
+if ! grep -q 'role="note"' "$tijdelijk"; then
+  echo "::error::Kon de omgevingsbalk niet plaatsen — <body> niet gevonden in $bestand" >&2
+  exit 1
+fi
+
+mv "$tijdelijk" "$bestand"
+echo "Omgevingsbalk geplaatst: ${titel} (${kort})"

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -48,6 +48,11 @@ jobs:
           git -C site rm -r --ignore-unmatch "dev/pr-${{ github.event.number }}"
           mkdir -p "site/dev/pr-${{ github.event.number }}"
           cp source/index.html "site/dev/pr-${{ github.event.number }}/index.html"
+          bash source/.github/scripts/omgevingsbalk.sh \
+            "site/dev/pr-${{ github.event.number }}/index.html" \
+            development \
+            "pull request #${{ github.event.number }}" \
+            "${{ github.event.pull_request.head.sha }}"
           cp source/README.md "site/dev/pr-${{ github.event.number }}/README.md"
           cp source/LICENSE "site/dev/pr-${{ github.event.number }}/LICENSE"
           printf '{"environment":"development","pull_request":%s,"branch":"%s","sha":"%s"}\n' \

--- a/.github/workflows/deploy-test.yml
+++ b/.github/workflows/deploy-test.yml
@@ -38,6 +38,11 @@ jobs:
           git -C site rm -r --ignore-unmatch test
           mkdir -p site/test
           cp source/index.html site/test/index.html
+          bash source/.github/scripts/omgevingsbalk.sh \
+            site/test/index.html \
+            test \
+            main \
+            "$GITHUB_SHA"
           cp source/README.md site/test/README.md
           cp source/LICENSE site/test/LICENSE
           printf '{"environment":"test","branch":"main","sha":"%s"}\n' "$GITHUB_SHA" > site/test/environment.json


### PR DESCRIPTION
Bovenaan een ontwikkel- of testversie komt een gekleurde balk te staan:

> **Ontwikkelversie — pull request #49 · versie `0706f66`**
> Dit is niet de echte site. Klopt dit versienummer niet met wat je verwacht, dan is het
> publiceren nog bezig — wacht een minuut en ververs de pagina.

## Waarom

Tussen "de controle is groen" en "de pagina toont de nieuwe versie" zit ongeveer een minuut
publiceertijd van GitHub Pages. Wie te vroeg kijkt, beoordeelt zonder het te merken de
vórige versie — er is niets op het scherm dat dat verraadt. Bij PR #49 was dat gemeten:
de workflow was groen, de pagina liet nog anderhalve minuut de oude versie zien.

Een waarschuwing in de PR-tekst lost dat maar half op, want die moet iemand onthouden. Met
het versienummer in beeld hoeft dat niet: je vergelijkt het met de pull request en weet het
meteen.

Tweede winst: een ontwikkel- of testversie kan niet meer per ongeluk voor de echte site
worden aangezien.

Overwogen en niet gedaan: tijdens het publiceren een "work in progress"-plaatje tonen. Dat
kan niet — GitHub blijft ondertussen gewoon de vorige versie serveren, en zo'n plaatje eerst
publiceren zou de wachttijd verdubbelen in plaats van hem oplossen.

## Wat er is gewijzigd

- **`.github/scripts/omgevingsbalk.sh`** (nieuw) — zet de balk in een gepubliceerde kopie.
- **`deploy-dev.yml`** en **`deploy-test.yml`** roepen dat script aan.

De kleuren volgen de kaart: ontwikkel oker (`--warn`), test blauw (`--accent`) — dezelfde
kleuren die het omgevingsfilter al gebruikt.

## Wat er bewust niet gebeurt

- **Productie krijgt geen balk.** Daar hoort geen ruis; dat ís de echte site.
- **`index.html` in de repository verandert niet.** De balk wordt pas bij het publiceren
  toegevoegd, dus het gedeelde bestand blijft schoon en de rooktest merkt er niets van.
- Het script plaatst de balk maximaal één keer, ook als hij per ongeluk twee keer draait.

## Wat te checken

Kijk in de ontwikkelomgeving van deze pull request (adres staat hieronder in de eerste
opmerking). Verwacht: een okerkleurige balk bovenaan met het versienummer van de laatste
commit van deze branch. De simulatie eronder werkt ongewijzigd.

Na de merge verschijnt dezelfde balk in blauw op `/test/`. De hoofdpagina blijft schoon.