### PR TITLE
feat: gebruik gesimuleerde data in ontwikkelomgevingen

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,7 +38,7 @@ De nul-dependency `index.html` blijft de downloadbare referentiedemo. `sveltekit
 
 Alle logica zit in één IIFE onderin `index.html`. Kernstate is het object `S` (aangemaakt in `freshState()`):
 
-- `loadRepositoryDashboard()` leest read-only de publieke GitHub REST API van deze repository. Eén snapshot bestaat uit metadata, maximaal 100 commits op de standaardbranch, branches, issues en PR's; `sessionStorage` bewaart hem vijf minuten. De API-fouttoestand mag de simulatie nooit blokkeren.
+- `loadRepositoryDashboard()` gebruikt in de ontwikkelomgeving van pull requests een vaste gesimuleerde snapshot en doet daar geen GitHub API-calls. Op test en live leest hij read-only de publieke GitHub REST API van deze repository. Eén echte snapshot bestaat uit metadata, maximaal 100 commits op de standaardbranch, branches, issues en PR's; `sessionStorage` bewaart hem vijf minuten. De API-fouttoestand mag de simulatie nooit blokkeren.
 - API-inhoud wordt voor weergave altijd ge-escaped en GitHub-links worden op het verwachte HTTPS-domein gecontroleerd. Voeg nooit een token, login of private-repositoryroute aan browsercode toe.
 
 - `S.commits[]` — elke commit: `{id, branch, msg, parents[], kind, x}`. `kind` ∈ `normal | merge | squash | revert`. `x` is de horizontale positie op de kaart (globale volgorde).
@@ -99,6 +99,11 @@ Deze repository heeft drie echte omgevingen, met dezelfde namen en regels als op
 - openstaande pull request → **ontwikkel** op `/dev/pr-<nummer>/` (`.github/workflows/deploy-dev.yml`)
 - `main` → **test** op `/test/` (`.github/workflows/deploy-test.yml`)
 - handmatige `.github/workflows/promote-production.yml` → **productie** op `/`
+
+De ontwikkelpagina gebruikt ingebedde gesimuleerde repository-, build- en releasegegevens en
+maakt geen verbinding met de GitHub API. Test en productie gebruiken juist de echte publieke
+GitHub-gegevens. Zo is de pull-requestweergave deterministisch, terwijl na merge de echte
+integratie op test wordt gecontroleerd.
 
 Elke workflow raakt uitsluitend zijn eigen map aan. De ontwikkelomgeving wordt bijgewerkt bij
 elke push naar de pull request en automatisch opgeruimd zodra die sluit.

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -4,17 +4,22 @@ Deze repository gebruikt één beschermde bronbranch en één GitHub Pages-site.
 
 | Omgeving | Bronbranch | URL |
 |---|---|---|
+| Ontwikkel | iedere open pull request, met gesimuleerde GitHub-data | `https://lxdg-technologies.github.io/git-routekaart-demo/dev/pr-<nummer>/` |
 | Productie | handmatige promotie van de geteste versie | `https://lxdg-technologies.github.io/git-routekaart-demo/` |
 | Test | iedere merge naar `main` | `https://lxdg-technologies.github.io/git-routekaart-demo/test/` |
 
 GitHub Pages ondersteunt één site per repository. De deploymentbranch `gh-pages` bevat daarom
-productie in de root en test in `test/`. De workflow `.github/workflows/deploy-test.yml`
-vervangt na een merge naar `main` uitsluitend de testmap. Productie blijft ongewijzigd.
+productie in de root, test in `test/` en een ontwikkelkopie per pull request in `dev/pr-<nummer>/`.
+De workflow `.github/workflows/deploy-test.yml` vervangt na een merge naar `main` uitsluitend de
+testmap. Productie blijft ongewijzigd. Ontwikkel gebruikt vaste ingebedde voorbeeldgegevens voor
+het repositorydashboard en de releasebadge; alleen test en productie verbinden met de publieke
+GitHub API.
 
 ## GitHub Environments
 
-De repository heeft twee echte GitHub Environments:
+De repository heeft drie echte GitHub Environments:
 
+- `development` — gebruikt door de tijdelijke ontwikkelkopie van iedere open pull request.
 - `test` — gebruikt door de automatische testdeployment na een merge naar `main`.
 - `live` — gebruikt door de handmatig gestarte promotieworkflow; vereist goedkeuring door
   `DCS-Rob` of `vdbergkevin` en staat zelfgoedkeuring niet toe. Eén van beide goedkeuringen

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Zie [DEPLOYMENT.md](DEPLOYMENT.md) voor de technische inrichting en controles.
 
 ## Echte repositorygegevens
 
-De dashboardkaart boven de simulatie leest rechtstreeks uit de publieke GitHub REST API voor [`lxdg-technologies/git-routekaart-demo`](https://github.com/lxdg-technologies/git-routekaart-demo):
+Op test en live leest de dashboardkaart boven de simulatie rechtstreeks uit de publieke GitHub REST API voor [`lxdg-technologies/git-routekaart-demo`](https://github.com/lxdg-technologies/git-routekaart-demo):
 
 - maximaal 100 recente commits op de standaardbranch;
 - maximaal 100 branches;
@@ -26,6 +26,8 @@ De dashboardkaart boven de simulatie leest rechtstreeks uit de publieke GitHub R
 - maximaal 100 recent bijgewerkte pull requests.
 
 De pagina gebruikt geen token en heeft geen eigen backend. Eén snapshot wordt vijf minuten in de browsersessie bewaard om de publieke API-limiet te ontzien. Als GitHub tijdelijk niet bereikbaar is, blijft de simulatie zelfstandig werken en linken de kolommen rechtstreeks naar GitHub.
+
+De ontwikkelomgeving van een pull request (`/dev/pr-<nummer>/`) gebruikt bewust vaste gesimuleerde repository- en releasegegevens. Daardoor is een wijziging voorspelbaar te beoordelen en doet de ontwikkelpagina zelf geen verzoeken aan de GitHub API. Na merge controleert test dezelfde code met de echte publieke gegevens; live gebruikt eveneens de echte API.
 
 ## Wat je ermee oefent
 

--- a/WERKWIJZE.md
+++ b/WERKWIJZE.md
@@ -110,6 +110,7 @@ Wat dat wél doet: voorkomen dat er ongemerkt iets binnenkomt. Wat het níet doe
 
 Nieuwste bovenaan. Eén regel per besluit, altijd met datum.
 
+- **07-08-2026** — De ontwikkelomgeving van pull requests gebruikt vaste gesimuleerde repository-, build- en releasegegevens en doet geen GitHub API-calls. Daardoor beoordeel je een wijziging tegen een voorspelbare dataset; na merge bewijst test de koppeling met de echte publieke GitHub-gegevens en live gebruikt diezelfde echte koppeling.
 - **07-08-2026** — Elke openstaande pull request krijgt een eigen ontwikkelomgeving op `/dev/pr-<nummer>/`. Daarmee heeft de repository dezelfde drie omgevingen als de kaart, en is er weer een moment om een wijziging te bekijken vóórdat hij op `main` staat — wat verdween toen de oude PR-previews vervielen. Bewust "ontwikkelomgeving" genoemd en niet "preview", zodat kaart en werkelijkheid dezelfde woorden gebruiken. Bewust één plek per pull request, omdat de kaart leert dat Ontwikkel van jou alleen is.
 - **07-08-2026** — De repository publiceert niet langer rechtstreeks naar live bij elke merge. Merge gaat naar test; live verandert alleen door een handmatige promotie van exact de geteste versie. Daarmee stopt de tegenstrijdigheid dat het leermiddel iets afraadde wat het zelf deed.
 - **07-08-2026** — Een read-only dashboard met echte publieke repositorygegevens staat boven de simulatie. Het vormt de brug van oefenen naar herkennen, verandert geen GitHub-data en voegt geen missie toe.

--- a/index.html
+++ b/index.html
@@ -567,6 +567,35 @@
   const REPOSITORY_CACHE_KEY = `git-routekaart-repository-v1:${REPOSITORY_FULL_NAME}`;
   const REPOSITORY_CACHE_TTL = 5 * 60 * 1000;
 
+  function repositoryUsesSimulatedData() {
+    return typeof location !== "undefined" && /\/dev\/pr-\d+(?:\/|$)/.test(location.pathname || "");
+  }
+  function simulatedRepositorySnapshot() {
+    const repositoryUrl = `https://github.com/${REPOSITORY_FULL_NAME}`;
+    return {
+      savedAt: Date.now(),
+      repository: { default_branch: "main" },
+      commits: [
+        { sha: "de10001aabbcc", html_url: `${repositoryUrl}/commits/main`, commit: { message: "feat: voorbeeldwijziging klaar voor review", author: { date: "2026-08-07T10:00:00Z" } } },
+        { sha: "de10000aabbcc", html_url: `${repositoryUrl}/commits/main`, commit: { message: "test: controleer het voorbeeldgedrag", author: { date: "2026-08-07T09:30:00Z" } } },
+      ],
+      branches: [
+        { name: "main", protected: true, commit: { sha: "a11ce00aabbcc" } },
+        { name: "feat/voorbeeld", protected: false, commit: { sha: "de10001aabbcc" } },
+      ],
+      issues: [
+        { number: 12, title: "Voorbeeld: maak de startpagina duidelijker", state: "open", updated_at: "2026-08-07T09:00:00Z", html_url: `${repositoryUrl}/issues` },
+      ],
+      prs: [
+        { number: 13, title: "Voorbeeld: verbeter de startpagina", state: "open", merged_at: null, updated_at: "2026-08-07T10:00:00Z", html_url: `${repositoryUrl}/pulls`, head: { ref: "feat/voorbeeld" }, base: { ref: "main" } },
+      ],
+    };
+  }
+  const SIMULATED_RELEASES = [
+    { tag_name: "v0.1.1", published_at: "2026-08-06T12:00:00Z", html_url: `https://github.com/${REPOSITORY_FULL_NAME}/releases` },
+    { tag_name: "v0.1.0", published_at: "2026-08-05T12:00:00Z", html_url: `https://github.com/${REPOSITORY_FULL_NAME}/releases` },
+  ];
+
   function escapeRepositoryHtml(value) {
     return String(value ?? "")
       .replace(/&/g, "&amp;")
@@ -631,12 +660,17 @@
   function renderRepositoryDashboard(snapshot, source) {
     const { repository, commits, branches, issues, prs } = snapshot;
     const repositoryUrl = `https://github.com/${REPOSITORY_FULL_NAME}`;
+    const simulated = source === "simulated";
     const repoLink = el("repository-link");
     repoLink.href = repositoryUrl;
     repoLink.textContent = `${REPOSITORY_FULL_NAME} ↗`;
     el("repository-status").className = "repository-status";
-    el("repository-status").textContent = `Rechtstreeks uit GitHub · publieke gegevens · hoofdbranch ${repository.default_branch || "main"}${source === "cache" ? " · tijdelijk uit browsercache" : ""}`;
-    el("repository-updated").textContent = `Bijgewerkt ${new Date(snapshot.savedAt).toLocaleTimeString("nl-NL", { hour: "2-digit", minute: "2-digit" })}`;
+    el("repository-status").textContent = simulated
+      ? "Gesimuleerde GitHub-gegevens · ontwikkelomgeving · geen verbinding met de GitHub API"
+      : `Rechtstreeks uit GitHub · publieke gegevens · hoofdbranch ${repository.default_branch || "main"}${source === "cache" ? " · tijdelijk uit browsercache" : ""}`;
+    el("repository-updated").textContent = simulated
+      ? "Vaste voorbeeldgegevens voor deze ontwikkelomgeving"
+      : `Bijgewerkt ${new Date(snapshot.savedAt).toLocaleTimeString("nl-NL", { hour: "2-digit", minute: "2-digit" })}`;
     el("repository-summary").innerHTML = [
       [branches.length, "branches"],
       [commits.length, `commits op ${repository.default_branch || "main"} geladen`],
@@ -655,7 +689,7 @@
     renderRepositoryList("repository-branches", branches, branch => {
       const name = branch.name || "branch zonder naam";
       const sha = String(branch.commit?.sha || "").slice(0, 7);
-      const url = `${repositoryUrl}/tree/${encodeURIComponent(name)}`;
+      const url = simulated ? `${repositoryUrl}/branches` : `${repositoryUrl}/tree/${encodeURIComponent(name)}`;
       return `<li><a href="${escapeRepositoryHtml(url)}" target="_blank" rel="noreferrer">${escapeRepositoryHtml(name)}</a><span class="repository-meta"><span>${escapeRepositoryHtml(sha)}</span><span>${branch.protected ? "beschermd" : "actief"}</span></span></li>`;
     }, "Geen branches gevonden.");
 
@@ -678,6 +712,11 @@
     refresh.disabled = true;
     status.className = "repository-status";
     status.textContent = force ? "GitHub-gegevens worden opnieuw opgehaald…" : "GitHub-gegevens worden opgehaald…";
+    if (repositoryUsesSimulatedData()) {
+      renderRepositoryDashboard(simulatedRepositorySnapshot(), "simulated");
+      refresh.disabled = false;
+      return;
+    }
     if (!force) {
       const cached = repositoryCacheRead();
       if (cached) {
@@ -722,9 +761,9 @@
   const RELEASE_HISTORY_API_URL = `${REPOSITORY_API_ROOT}/releases?per_page=5`;
   const RELEASE_TAGS_API_URL = `${REPOSITORY_API_ROOT}/tags?per_page=1`;
   const RELEASE_ENVIRONMENT = typeof location !== "undefined"
-    ? (location.protocol === "file:" || ["localhost", "127.0.0.1"].includes(location.hostname)
+    ? (location.protocol === "file:" || ["localhost", "127.0.0.1"].includes(location.hostname) || repositoryUsesSimulatedData()
       ? "dev"
-      : location.pathname.includes("/pr-preview/") ? "test" : "live")
+      : location.pathname.includes("/test/") || location.pathname.includes("/pr-preview/") ? "test" : "live")
     : "dev";
 
   function setupReleaseBadge() {
@@ -781,6 +820,11 @@
   }
   async function loadReleaseHistory() {
     const badge = el("release-history");
+    if (repositoryUsesSimulatedData()) {
+      renderReleaseHistory(SIMULATED_RELEASES);
+      badge.dataset.historyLoaded = "true";
+      return;
+    }
     if (typeof fetch !== "function") {
       renderReleaseHistory([]);
       badge.dataset.historyLoaded = "true";
@@ -819,6 +863,15 @@
     }
   }
   async function loadLatestRelease() {
+    if (repositoryUsesSimulatedData()) {
+      setReleaseBuild(
+        { version: "voorbeeld", commitsAhead: 1, sha: "de10001" },
+        "simulated",
+        "Gesimuleerde buildinformatie voor de ontwikkelomgeving; test en live lezen de echte versiegegevens.",
+        `https://github.com/${REPOSITORY_FULL_NAME}/pulls`,
+      );
+      return;
+    }
     const stamped = await loadVersionFile();
     if (stamped.status === "ready") {
       setReleaseBuild(stamped.build, "version-file", "Deze badge is gestempeld bij de deploy en beschrijft exact de build op deze pagina.", stamped.build.version && `https://github.com/${REPOSITORY_FULL_NAME}/releases/tag/${encodeURIComponent(stamped.build.version)}`);

--- a/test/checks/repository-dashboard.js
+++ b/test/checks/repository-dashboard.js
@@ -1,5 +1,5 @@
 // Controles voor de read-only koppeling met de echte publieke GitHub-repository.
-module.exports = async function repositoryDashboard({ assert, flush, byIdMap, fetchCalls }) {
+module.exports = async function repositoryDashboard({ assert, flush, byIdMap, fetchCalls, stappen }) {
   await flush(); await flush(); await flush();
   assert(byIdMap["repository-link"].href === "https://github.com/lxdg-technologies/git-routekaart-demo", "repositorydashboard linkt naar de gekoppelde repository");
   assert(byIdMap["repository-status"].textContent.includes("Rechtstreeks uit GitHub") && !byIdMap["repository-status"].className.includes("error"), "repositorydashboard meldt een geslaagde publieke API-koppeling");
@@ -14,4 +14,20 @@ module.exports = async function repositoryDashboard({ assert, flush, byIdMap, fe
   byIdMap["repository-refresh"].onclick();
   await flush(); await flush(); await flush();
   assert(fetchCalls.length >= callsBeforeRefresh + 5 && byIdMap["repository-refresh"].disabled === false, "handmatig vernieuwen omzeilt de cache en rondt af");
+
+  const callsBeforeDevelopment = fetchCalls.length;
+  global.location = { protocol: "https:", hostname: "lxdg-technologies.github.io", pathname: "/git-routekaart-demo/dev/pr-51/" };
+  stappen.opnieuw();
+  byIdMap["repository-refresh"].onclick();
+  await flush(); await flush(); await flush();
+  assert(fetchCalls.length === callsBeforeDevelopment, "ontwikkelomgeving doet geen fetch naar GitHub of een andere databron");
+  assert(byIdMap["repository-status"].textContent.includes("Gesimuleerde GitHub-gegevens") && byIdMap["repository-status"].textContent.includes("geen verbinding met de GitHub API"), "ontwikkelomgeving benoemt de gesimuleerde databron duidelijk");
+  assert(byIdMap["repository-commits"].innerHTML.includes("voorbeeldwijziging") && byIdMap["repository-prs"].innerHTML.includes("Voorbeeld: verbeter de startpagina"), "ontwikkelomgeving rendert de vaste voorbeeldgegevens");
+  assert(byIdMap["release-history"].dataset.source === "simulated" && byIdMap["release-badge-label"].textContent.includes("voorbeeld"), "ontwikkelomgeving simuleert ook de buildinformatie");
+  byIdMap["release-history"].open = true;
+  byIdMap["release-history"].dataset.historyLoaded = "false";
+  byIdMap["release-history"].ontoggle();
+  await flush(); await flush();
+  assert(fetchCalls.length === callsBeforeDevelopment && byIdMap["release-history-list"].children.length === 2, "ontwikkelomgeving toont gesimuleerde releasehistorie zonder API-call");
+  delete global.location;
 };


### PR DESCRIPTION
## Wat verandert

- Pull-requestomgevingen onder `/dev/pr-<nummer>/` gebruiken vaste gesimuleerde repositorygegevens.
- Ook buildinformatie en releasehistorie zijn daar gesimuleerd.
- De ontwikkelpagina doet daardoor geen fetch en maakt geen verbinding met de GitHub API.
- Test en live blijven de echte publieke GitHub API gebruiken.
- Het scherm vermeldt duidelijk dat de getoonde gegevens gesimuleerd zijn.

## Waarom

De ontwikkelomgeving is bedoeld om een wijziging voorspelbaar te beoordelen. Echte GitHub-data beweegt ondertussen mee met branches, issues en andere pull requests en kan bovendien tegen de publieke API-limiet lopen. Een vaste dataset maakt de PR-preview reproduceerbaar; na merge controleert test bewust de echte integratie.

## Impact

Er veranderen geen GitHub Environment-regels en geen deploymentpaden. De keuze gebeurt in de pagina zelf aan de hand van het bestaande pad `/dev/pr-<nummer>/`, waardoor deze wijziging niet botst met de omgevingsbalk uit PR #51.

## Verificatie

- `node test/smoketest.js`: alle 88 controles geslaagd.
- Nieuwe controles bewijzen dat development geen enkele fetch uitvoert en wel repository-, build- en releasefixtures rendert.
- De bestaande controles bewijzen dat de echte API-route voor de andere omgevingen blijft werken.
- Lokale browsercontrole: gesimuleerde status, voorbeeldgegevens en buildbron zichtbaar; geen consolewaarschuwingen of fouten.
- `git diff --check`: schoon.

## Wat te checken

Open de ontwikkelomgeving van deze PR. Boven het echte leergedeelte moet staan: **Gesimuleerde GitHub-gegevens · ontwikkelomgeving · geen verbinding met de GitHub API**. Klik **Vernieuwen** en controleer dat dezelfde voorbeeldgegevens blijven staan.