### PR TITLE
Blokkeer een uitrol die niet weet welke versie hij draait

### DIFF
--- a/.github/scripts/controleer-versiebestand.sh
+++ b/.github/scripts/controleer-versiebestand.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# Controleert dat een uitgerolde omgeving weet welke versie hij is, vóórdat hij gepubliceerd wordt.
+#
+# Waarom: op 07-08-2026 stond live zonder version.json, omdat die omgeving ooit was uitgerold
+# door een oudere workflow die dat bestand nog niet meeschreef. Gevolg: de pagina wist niet wat
+# hij was en toonde de nieuwste GitHub-uitgave alsof dat de draaiende versie was — een gok die
+# eruitzag als een feit.
+#
+# Beter een uitrol die stopt met een duidelijke melding dan een omgeving die stilzwijgend niet
+# weet wat hij draait.
+#
+# Gebruik: controleer-versiebestand.sh <map> <verwachte-versie> <verwachte-sha>
+
+set -euo pipefail
+
+map="$1"
+verwachte_versie="$2"
+verwachte_sha="$3"
+
+fout() {
+  echo "::error::$1"
+  exit 1
+}
+
+for bestand in version.json environment.json; do
+  [ -f "$map/$bestand" ] || fout "De uitrol in $map heeft geen $bestand — de omgeving zou niet weten welke versie hij draait."
+  [ -s "$map/$bestand" ] || fout "$map/$bestand is leeg."
+done
+
+python3 - "$map/version.json" "$map/environment.json" "$verwachte_versie" "$verwachte_sha" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+version_pad, environment_pad, verwachte_versie, verwachte_sha = sys.argv[1:]
+
+
+def fout(bericht):
+    print(f"::error::{bericht}")
+    sys.exit(1)
+
+
+def lees(pad):
+    try:
+        return json.loads(Path(pad).read_text())
+    except json.JSONDecodeError as exc:
+        fout(f"{pad} is geen geldige JSON: {exc}")
+
+
+version = lees(version_pad)
+environment = lees(environment_pad)
+
+for sleutel in ("version", "sha"):
+    if not version.get(sleutel):
+        fout(f"{version_pad} mist het veld {sleutel}.")
+    if not environment.get(sleutel):
+        fout(f"{environment_pad} mist het veld {sleutel}.")
+
+if version["version"] != verwachte_versie:
+    fout(f"{version_pad} noemt versie {version['version']} in plaats van {verwachte_versie}.")
+if environment["version"] != verwachte_versie:
+    fout(f"{environment_pad} noemt versie {environment['version']} in plaats van {verwachte_versie}.")
+if version["sha"] != verwachte_sha:
+    fout(f"{version_pad} noemt commit {version['sha']} in plaats van {verwachte_sha}.")
+if environment["sha"] != verwachte_sha:
+    fout(f"{environment_pad} noemt commit {environment['sha']} in plaats van {verwachte_sha}.")
+
+print(f"Versiebestanden kloppen: {verwachte_versie} ({verwachte_sha[:7]})")
+PY

--- a/.github/workflows/deploy-test.yml
+++ b/.github/workflows/deploy-test.yml
@@ -184,6 +184,15 @@ jobs:
           }, separators=(",", ":")) + "\n")
           PY
 
+      - name: Controleer dat test weet welke versie hij draait
+        shell: bash
+        env:
+          VERSION: ${{ needs.version.outputs.version }}
+        run: |
+          set -euo pipefail
+          bash source/.github/scripts/controleer-versiebestand.sh site/test "$VERSION" "$GITHUB_SHA"
+          bash source/.github/scripts/controleer-versiebestand.sh "site/versions/$VERSION" "$VERSION" "$GITHUB_SHA"
+
       - name: Publish version and test if changed
         working-directory: site
         shell: bash

--- a/.github/workflows/promote-production.yml
+++ b/.github/workflows/promote-production.yml
@@ -133,6 +133,12 @@ jobs:
           PY
           touch site/.nojekyll
 
+      - name: Controleer dat productie weet welke versie hij draait
+        shell: bash
+        run: |
+          set -euo pipefail
+          bash source/.github/scripts/controleer-versiebestand.sh site "$TARGET_VERSION" "$TARGET_SHA"
+
       - name: Publish production if changed
         working-directory: site
         shell: bash


### PR DESCRIPTION
De vervolgstap uit #64, het deel dat het agents-account niet kan uitvoeren.

## Aanleiding

De live-site toonde op 07-08-2026 `release: v1.2.2` terwijl hij `968eb8d` draaide. Oorzaak:
op live ontbrak het versiebestand, omdat die omgeving ooit is uitgerold door een oudere
workflow die dat nog niet meeschreef. Zonder dat bestand weet de pagina niet wat hij is, en
toont hij de nieuwste GitHub-uitgave alsof dat de draaiende versie is.

Beide workflows schrijven dat bestand inmiddels wel. Maar er is niets dat **controleert** dat
het er ook echt staat — dus dezelfde stille fout kan terugkomen bij de volgende wijziging.

**Beter een uitrol die stopt met een duidelijke melding dan een omgeving die niet weet wat hij
draait.** Dat is dezelfde afweging als eerder bij de release-pipeline: bij een terugkerende
fout hoort een technische borging, niet nog een regel die iemand moet onthouden.

## Wat er is gewijzigd

- **`.github/scripts/controleer-versiebestand.sh`** (nieuw) — controleert vóór publiceren dat
  `version.json` en `environment.json` bestaan, geldige JSON zijn, en dezelfde versie en
  commit noemen als de uitrol bedoelt.
- **`deploy-test.yml`** controleert zowel de testmap als het versie-archief.
- **`promote-production.yml`** controleert de productiemap.

Beide controles staan **vóór** de publicatiestap: faalt de controle, dan wordt er niets
gepubliceerd en blijft de bestaande omgeving ongemoeid.

## Getest

Handmatig gedraaid op een Linux-machine, met alle vier de gevallen:

| Geval | Uitkomst |
|---|---|
| Alles klopt | slaagt, meldt `Versiebestanden kloppen: v1.2.2 (abc123)` |
| `version.json` ontbreekt | faalt met een begrijpelijke melding |
| Verkeerde versie in het bestand | faalt en noemt beide versienummers |
| Kapotte JSON | faalt en noemt de leesfout |

Dat laatste is bewust getoetst: een controle die alleen het goede geval aantoont, kan stil
niets doen — dat patroon heeft dit project eerder gehad.

## Wat dit niet doet

- Geen enkele bestaande controle vervangen of versoepelen.
- Geen wijziging aan `index.html`. Het gedrag van de badge zelf is #64.
- Geen wijziging aan wat er gepubliceerd wordt — alleen een weigering als de uitrol niet
  compleet is.
- Repareert niets met terugwerkende kracht: live krijgt zijn versiebestand pas bij de
  eerstvolgende promotie.

## Wat te checken

Deze pull request verandert de simulatie niet, dus de ontwikkelomgeving toont hetzelfde als nu.
Het echte bewijs is de eerstvolgende uitrol naar test: die moet gewoon slagen, met een extra
groene stap `Controleer dat test weet welke versie hij draait`.