### PR TITLE
Promoveren zonder het versienummer te hoeven opzoeken — Fixes #62

### DIFF
--- a/.github/workflows/promote-production.yml
+++ b/.github/workflows/promote-production.yml
@@ -4,8 +4,9 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: Version tag to publish, for example v1.2.0
-        required: true
+        description: Laat leeg om de versie te nemen die nu op test staat. Vul alleen iets in om terug te rollen naar een oudere versie, bijvoorbeeld v1.2.0
+        required: false
+        default: ""
         type: string
       confirm:
         description: I understand that this version will replace production
@@ -52,6 +53,27 @@ jobs:
             echo "::error::The confirmation checkbox must be selected"
             exit 1
           fi
+
+          # Geen versie ingevuld: neem wat er nu op test staat. Dat is de normale situatie —
+          # je promoveert wat je zojuist hebt goedgekeurd. Een versie invullen blijft mogelijk
+          # en is de manier om terug te rollen naar een oudere, al bewezen versie.
+          if [ -z "$VERSION" ]; then
+            if [ ! -s site/test/environment.json ]; then
+              echo "::error::De testomgeving heeft geen leesbare versiegegevens, dus er valt niets over te nemen. Vul handmatig een versie in."
+              exit 1
+            fi
+            VERSION="$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1])).get("version",""))' site/test/environment.json)"
+            if [ -z "$VERSION" ]; then
+              echo "::error::De testomgeving noemt geen versie. Vul handmatig een versie in."
+              exit 1
+            fi
+            SELECTIE="overgenomen van test"
+          else
+            SELECTIE="handmatig opgegeven"
+          fi
+          echo "Gekozen versie: $VERSION ($SELECTIE)"
+          printf '## Promotie naar live\n\nVersie **%s** — %s.\n' "$VERSION" "$SELECTIE" >> "$GITHUB_STEP_SUMMARY"
+
           if [[ ! "$VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             echo "::error::Version must look like v1.2.3"
             exit 1


### PR DESCRIPTION
Fixes #62

## Wat er verandert

Het versievak is niet meer verplicht. Laat je het leeg, dan neemt de workflow de versie die op
dat moment op **test** staat — dus precies wat je zojuist hebt bekeken en goedgekeurd.

Promoveren wordt daarmee: **vinkje aan → Run workflow.** Geen opzoekwerk meer.

## Waarom

Om te promoveren moest je `v1.2.2` intypen. Dat nummer staat nergens waar je het tegenkomt; je
moest twee adressen vergelijken of het navragen. Zelfs Rob, die de beslissing neemt, moest het
op 07-08 vragen. Voor iemand die het leerproject doorloopt is dat een blokkade.

De simulatie leert dat promoveren **één bewuste knop** is. Dit brengt de werkelijkheid daarnaar
toe.

## Wat bewust blijft

- **Het bevestigingsvinkje blijft verplicht.** Dat vraagt geen voorkennis en is het moment
  waarop je bewust zegt dat je dit wilt.
- **De goedkeuring door een tweede persoon blijft.** Live verandert nooit door één handeling
  van één mens.
- **Het versievak blijft bestaan.** Een oudere versie invullen is de manier om terug te rollen
  zonder opnieuw te bouwen; die mogelijkheid mag niet verdwijnen.
- **Alle bestaande controles blijven ongewijzigd** en draaien op de gekozen versie: vorm van het
  versienummer, bestaan van het archief, archief-metadata tegen de tag, de tag in de historie van
  `main`, en de bestandsvergelijking tegen de tag. Er wordt niets versoepeld — dit maakt het
  makkelijker te *bedienen*, niet makkelijker om iets ongetests live te zetten.

## Als het niet lukt

Kan de versie niet uit de testomgeving worden gelezen, dan stopt de workflow met een
begrijpelijke melding en de vraag om handmatig een versie in te vullen. Geen gok.

## Zichtbaarheid

De samenvatting van de run vermeldt welke versie is gekozen en of die is *overgenomen van test*
of *handmatig opgegeven*, zodat achteraf duidelijk is wat er is gebeurd.

## Getest

De YAML is gecontroleerd en alle verwijzingen naar de gekozen versie lopen door de bestaande
controles. Het echte bewijs is de eerstvolgende promotie: die moet slagen met een leeg versievak
en in de samenvatting *overgenomen van test* melden.