### PR TITLE
PR-sjabloon met uitleg voor Rob in gewone taal

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,7 +78,9 @@ Squash-gedrag op de kaart: gesquashte commits krijgen `c.squashed = true` en wor
 
 5. Controleer vóór het openen van de PR de volledige diff tegen de opdracht in het issue. Verwijder elke wijziging zonder grond in het issue, of breng die terug tot een los voorstel buiten de PR. Controleer daarbij ook of een verbetering die nuttig of technisch aantrekkelijk lijkt toch buiten de gevraagde scope valt.
 6. Open een PR met een duidelijke omschrijving in gewone taal (de reviewer is niet altijd technisch). **Elke PR die de simulatie zelf verandert (dus niet alleen CI/docs) krijgt een expliciete "wat te checken"-regel**, bijv. "Klik X aan en kijk of Y verschijnt". De beoordelaar kijkt in de ontwikkelomgeving van die pull request: `https://lxdg-technologies.github.io/git-routekaart-demo/dev/pr-<nummer>/`. Zonder zo'n regel is dat adres net zo nietszeggend als geen adres — het toont dát er iets is, niet wát.
-7. **Mergen doet een mens** (repo-eigenaar beslist) — een agent merget nooit zelf. Een merge naar `main` maakt automatisch één nieuwe patchversie en vernieuwt test; productie vereist daarna nog een afzonderlijke handmatige promotie van een expliciet gekozen versie.
+
+7. **Elke PR krijgt het sjabloon (`.github/PULL_REQUEST_TEMPLATE.md`) volledig ingevuld, met een sectie "Voor Rob — in gewone taal".** Daarin staan altijd twee dingen: wat er voor de gebruiker of voor Rob verandert (geen technische termen), en een directe link waar hij het zelf kan zien of uitproberen. Raakt de wijziging niets dat in de PR-preview zichtbaar is (bijvoorbeeld een workflowstap die pas bij de volgende release iets oplevert), gebruik dan een link naar waar het wél zichtbaar wordt — bijvoorbeeld de Releases-pagina — en zeg erbij wanneer daar iets te zien zal zijn. Aanleiding: PR #161 werkte goed, maar Rob moest er zelf naar vragen om te snappen wat hij moest testen.
+8. **Mergen doet een mens** (repo-eigenaar beslist) — een agent merget nooit zelf. Een merge naar `main` maakt automatisch één nieuwe patchversie en vernieuwt test; productie vereist daarna nog een afzonderlijke handmatige promotie van een expliciet gekozen versie.
 
 ## Wie regelt wat
 


### PR DESCRIPTION
## Wat verandert er voor jou

Elke volgende pull request begint voortaan met een verplicht ingevuld stukje bovenaan: wat de wijziging voor jou betekent, zonder vaktermen, en een directe link waar je het zelf kunt zien of uitproberen.

## Aanleiding

Bij PR #161 (release notes) moest je er zelf naar vragen wat je moest testen — de PR liet niets zien in de dev-preview, omdat het effect pas bij de eerstvolgende echte release zichtbaar wordt. Dat soort PR's ("werkt wel, maar toont niks in de preview") krijgt nu de instructie om naar de juiste plek te linken in plaats van naar de preview.

## Wat te checken

Dit wijzigt alleen documentatie en een sjabloon, geen gedrag van de simulatie. `node test/smoketest.js` hoeft hiervoor niet opnieuw — er is niets aan `index.html` gewijzigd.

## Raakt

`AGENTS.md` (regel 6 wordt aangevuld, vernummerd), nieuw `.github/PULL_REQUEST_TEMPLATE.md`.

## NIET in scope

Het aanpassen van bestaande, al gemergede PR's. Geldt vanaf nu.