### PR TITLE
Dwing de routeafspraken af in de kwaliteitspoort

### DIFF
--- a/.github/scripts/route-controle.py
+++ b/.github/scripts/route-controle.py
@@ -1,0 +1,214 @@
+#!/usr/bin/env python3
+"""Controleer dat een pull request de afspraken van zijn route nakomt.
+
+Twee regels, allebei afgedwongen in plaats van onthouden:
+
+1. Elke pull request heeft precies één `soort:`-label — op de PR zelf of op het
+   gekoppelde issue. Zonder dat label valt `synchroniseer-projectbord.py` terug
+   op een andere tak en zet de kaart in een baan die niet klopt; een kaart die
+   verkeerd staat komt daar nooit meer uit (issue #127).
+
+2. Een pull request met `route:sneltrein` is door Claude geschreven en geopend,
+   zonder Coder die test en zonder Reviewer die onafhankelijk meekijkt. Zo'n PR
+   mag daarom niets raken dat gedrag verandert. Gedrag gaat via de bouwroute.
+
+Deze controle faalt ook als hij zijn eigen gegevens niet kan vaststellen. Een
+groene uitslag moet betekenen dat er echt iets is nagekeken — niet dat er niets
+te vinden was.
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+from typing import Any, Iterable
+from urllib.error import HTTPError
+from urllib.request import Request, urlopen
+
+SOORT_LABELS = frozenset({"soort:routekaart", "soort:github"})
+SNELTREIN_LABEL = "route:sneltrein"
+
+# Wat "gedrag" is: alles wat de bezoeker ziet, wat de tests bewaken, en de
+# werkschema's en scripts die publiceren. Een fout hierin heeft de site eerder
+# twee dagen platgelegd, dus dit is precies wat een onafhankelijke blik nodig
+# heeft.
+GEDRAGSBESTANDEN = frozenset({"index.html"})
+GEDRAGSMAPPEN = ("test/", ".github/workflows/", ".github/scripts/")
+
+# Dezelfde vorm als `synchroniseer-projectbord.py` gebruikt om een PR aan een
+# issue te koppelen. Wijkt dit af, dan kan de controle iets anders vinden dan
+# het bord — en dan bewaakt hij de verkeerde werkelijkheid.
+KOPPELING = re.compile(r"\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+#(\d+)\b", re.I)
+
+
+def raakt_gedrag(pad: str) -> bool:
+    """Verandert dit bestand gedrag, of alleen tekst eromheen?"""
+    if pad in GEDRAGSBESTANDEN:
+        return True
+    return any(pad.startswith(map_) for map_ in GEDRAGSMAPPEN)
+
+
+def soort_labels(labels: Iterable[str]) -> frozenset[str]:
+    return frozenset(label for label in labels if label in SOORT_LABELS)
+
+
+def gekoppeld_issue(titel: str, tekst: str) -> int | None:
+    """Het issuenummer dat deze PR sluit, of None."""
+    match = KOPPELING.search(f"{titel}\n{tekst}")
+    return int(match.group(1)) if match else None
+
+
+def controleer(
+    pr_labels: Iterable[str],
+    issue_labels: Iterable[str],
+    bestanden: Iterable[str],
+) -> list[str]:
+    """Geef de problemen terug; een lege lijst betekent dat alles klopt."""
+    pr_labels = set(pr_labels)
+    bestanden = list(bestanden)
+    problemen: list[str] = []
+
+    # Het bord leest het soort van het gekoppelde issue, en pas daarna van de
+    # PR zelf. Dezelfde volgorde, zodat controle en bord niet van mening
+    # kunnen verschillen.
+    soorten = soort_labels(issue_labels) or soort_labels(pr_labels)
+    if not soorten:
+        problemen.append(
+            "Geen soort:-label. Zet soort:routekaart (de bezoeker ziet het) of "
+            "soort:github (het gereedschap zelf) op deze pull request, of op het "
+            "issue dat hij sluit. Zonder dat label komt de kaart op het bord in "
+            "de verkeerde baan te staan."
+        )
+    elif len(soorten) > 1:
+        problemen.append(
+            "Meer dan één soort:-label: "
+            + ", ".join(sorted(soorten))
+            + ". Kies er één, anders is niet te bepalen welke route het werk aflegt."
+        )
+
+    if SNELTREIN_LABEL in pr_labels:
+        geraakt = sorted(pad for pad in bestanden if raakt_gedrag(pad))
+        if geraakt:
+            problemen.append(
+                "Deze pull request draagt "
+                + SNELTREIN_LABEL
+                + " maar verandert gedrag: "
+                + ", ".join(geraakt)
+                + ". De sneltrein heeft geen onafhankelijke beoordeling. Haal het "
+                "label weg en laat dit via de bouwroute lopen (issue → Coder → "
+                "Reviewer), of splits de tekstwijziging af in een eigen pull request."
+            )
+
+    return problemen
+
+
+class GitHub:
+    def __init__(self, token: str, repository: str):
+        self.token = token
+        self.repository = repository
+
+    def rest(self, path: str) -> Any:
+        request = Request(
+            "https://api.github.com" + path,
+            headers={
+                "Authorization": f"Bearer {self.token}",
+                "Accept": "application/vnd.github+json",
+            },
+        )
+        try:
+            with urlopen(request) as response:
+                body = response.read()
+                return json.loads(body) if body else None
+        except HTTPError as error:
+            try:
+                antwoord = error.read().decode("utf-8", errors="replace")
+            except Exception:
+                antwoord = "(antwoord kon niet worden gelezen)"
+            raise RuntimeError(
+                f"GitHub-aanroep {path} mislukt: HTTP {error.code} {error.reason}; "
+                f"antwoord: {antwoord or '(leeg)'}"
+            ) from error
+
+    def bestanden(self, nummer: int) -> list[str]:
+        paden: list[str] = []
+        pagina = 1
+        while True:
+            batch = self.rest(f"/repos/{self.repository}/pulls/{nummer}/files?per_page=100&page={pagina}")
+            if not batch:
+                break
+            paden.extend(item["filename"] for item in batch)
+            if len(batch) < 100:
+                break
+            pagina += 1
+        return paden
+
+    def issue_labels(self, nummer: int) -> list[str]:
+        issue = self.rest(f"/repos/{self.repository}/issues/{nummer}")
+        return [label["name"] for label in issue.get("labels", []) if label.get("name")]
+
+
+def main() -> int:
+    event_path = os.environ.get("GITHUB_EVENT_PATH", "")
+    if not event_path or not os.path.exists(event_path):
+        print("::error::Geen GITHUB_EVENT_PATH; de controle kan niet vaststellen "
+              "welke pull request hij moet nakijken.", file=sys.stderr)
+        return 1
+    try:
+        with open(event_path, encoding="utf-8") as bestand:
+            payload = json.load(bestand)
+    except Exception as fout:
+        print(f"::error::Kan de gebeurtenis niet lezen: {fout}", file=sys.stderr)
+        return 1
+
+    pull_request = payload.get("pull_request")
+    if not isinstance(pull_request, dict) or not pull_request.get("number"):
+        print("::error::Deze gebeurtenis gaat niet over een pull request.", file=sys.stderr)
+        return 1
+
+    nummer = pull_request["number"]
+    pr_labels = [label["name"] for label in pull_request.get("labels", []) if label.get("name")]
+    repository = (payload.get("repository") or {}).get("full_name", "")
+    if not repository:
+        print("::error::De gebeurtenis noemt geen repository.", file=sys.stderr)
+        return 1
+
+    token = os.environ.get("GITHUB_TOKEN", "")
+    if not token:
+        print("::error::GITHUB_TOKEN ontbreekt; zonder token zijn de gewijzigde "
+              "bestanden niet op te vragen en zou de controle onterecht slagen.",
+              file=sys.stderr)
+        return 1
+
+    client = GitHub(token, repository)
+    try:
+        bestanden = client.bestanden(nummer)
+        issue_nummer = gekoppeld_issue(pull_request.get("title") or "", pull_request.get("body") or "")
+        issue_labels = client.issue_labels(issue_nummer) if issue_nummer else []
+    except RuntimeError as fout:
+        print(f"::error::{fout}", file=sys.stderr)
+        return 1
+
+    # Een pull request zonder gewijzigde bestanden bestaat niet. Zien we er geen,
+    # dan hebben we de verkeerde gegevens en mag de uitslag niet groen zijn.
+    if not bestanden:
+        print(f"::error::Pull request #{nummer} levert geen gewijzigde bestanden op. "
+              "De controle kon zijn gegevens niet vaststellen en slaagt daarom niet.",
+              file=sys.stderr)
+        return 1
+
+    problemen = controleer(pr_labels, issue_labels, bestanden)
+    if problemen:
+        for probleem in problemen:
+            print(f"::error::{probleem}", file=sys.stderr)
+        return 1
+
+    soorten = ", ".join(sorted(soort_labels(issue_labels) or soort_labels(pr_labels)))
+    route = SNELTREIN_LABEL if SNELTREIN_LABEL in pr_labels else "bouwroute"
+    print(f"Routecontrole geslaagd voor #{nummer}: {len(bestanden)} bestand(en), "
+          f"soort {soorten}, route {route}.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -4,8 +4,20 @@ name: Quality
 on:
   pull_request:
     branches: [main]
+    # labeled en unlabeled staan hier omdat de routecontrole naar labels kijkt.
+    # Zonder die twee kan een pull request die op een ontbrekend label faalde niet
+    # groen worden door dat label toe te voegen — daar zou een lege commit voor
+    # nodig zijn, en dan wordt de poort iets om omheen te werken.
+    types: [opened, synchronize, reopened, labeled, unlabeled]
   push:
     branches: [main]
+
+# Expliciet en alleen lezen. De routecontrole vraagt de gewijzigde bestanden en
+# de labels van het gekoppelde issue op; geen enkele stap in deze poort schrijft.
+permissions:
+  contents: read
+  pull-requests: read
+  issues: read
 
 jobs:
   quality:
@@ -42,3 +54,12 @@ jobs:
 
       - name: ProjectV2-synchronisatie testen
         run: python3 test/projectbord.py
+
+      - name: Routecontrole testen
+        run: python3 test/route-controle.py
+
+      - name: Routecontrole op deze pull request
+        if: github.event_name == 'pull_request'
+        run: python3 .github/scripts/route-controle.py
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/test/route-controle.py
+++ b/test/route-controle.py
@@ -1,0 +1,239 @@
+#!/usr/bin/env python3
+"""Gedragstests voor de routecontrole (geen GitHub-aanroepen).
+
+Elke regel wordt zowel groen als rood getest. Een controle die alleen op zijn
+goede geval is getest, kan stil niets doen — dat is hier eerder gebeurd met een
+kwaliteitspoort die groen stond op de verkeerde vraag.
+"""
+import importlib.util
+import json
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+ROOT = Path(__file__).parents[1]
+spec = importlib.util.spec_from_file_location("route_controle", ROOT / ".github/scripts/route-controle.py")
+if spec is None or spec.loader is None:
+    raise RuntimeError("kan routecontrolescript niet laden")
+route = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = route
+spec.loader.exec_module(route)
+
+
+class RaaktGedrag(unittest.TestCase):
+    def test_de_simulatiepagina_is_gedrag(self):
+        self.assertTrue(route.raakt_gedrag("index.html"))
+
+    def test_tests_werkschemas_en_scripts_zijn_gedrag(self):
+        for pad in ("test/smoketest.js", "test/checks/kaart.js",
+                    ".github/workflows/quality.yml", ".github/scripts/bepaal-versie.sh"):
+            with self.subTest(pad=pad):
+                self.assertTrue(route.raakt_gedrag(pad))
+
+    def test_tekst_eromheen_is_geen_gedrag(self):
+        for pad in ("AGENTS.md", "WERKWIJZE.md", "README.md",
+                    ".github/PULL_REQUEST_TEMPLATE.md", ".github/REVIEW.md"):
+            with self.subTest(pad=pad):
+                self.assertFalse(route.raakt_gedrag(pad))
+
+    def test_een_gelijknamig_bestand_elders_is_geen_gedrag(self):
+        # index.html geldt alleen in de wortel; een toevallige naamgenoot in een
+        # andere map mag de sneltrein niet blokkeren.
+        self.assertFalse(route.raakt_gedrag("docs/index.html"))
+
+    def test_een_maplijkende_naam_is_geen_gedrag(self):
+        # "testplan.md" begint met "test" maar zit niet in de map test/.
+        self.assertFalse(route.raakt_gedrag("testplan.md"))
+
+
+class Koppeling(unittest.TestCase):
+    def test_vindt_het_gesloten_issue(self):
+        for tekst in ("Fixes #164", "fixes #164", "Closes #164", "resolved #164"):
+            with self.subTest(tekst=tekst):
+                self.assertEqual(route.gekoppeld_issue("", tekst), 164)
+
+    def test_vindt_de_koppeling_ook_in_de_titel(self):
+        self.assertEqual(route.gekoppeld_issue("fix: iets (Fixes #7)", ""), 7)
+
+    def test_een_losse_verwijzing_is_geen_koppeling(self):
+        # "zie #164" koppelt niet; het bord doet dat ook niet.
+        self.assertIsNone(route.gekoppeld_issue("", "zie #164 voor context"))
+
+
+class SoortLabelRegel(unittest.TestCase):
+    def test_soort_op_de_pull_request_is_genoeg(self):
+        self.assertEqual(route.controleer(["soort:github"], [], ["AGENTS.md"]), [])
+
+    def test_soort_op_het_gekoppelde_issue_is_genoeg(self):
+        # Het bord leest het soort van het issue; Coder krijgt zijn PR-label pas
+        # ná de synchronisatie. Zou de controle dat niet accepteren, dan faalde
+        # elke correcte Coder-PR bij het openen.
+        self.assertEqual(route.controleer([], ["soort:routekaart"], ["index.html"]), [])
+
+    def test_zonder_soort_faalt_het(self):
+        problemen = route.controleer(["van:rob"], [], ["AGENTS.md"])
+        self.assertEqual(len(problemen), 1)
+        self.assertIn("Geen soort:-label", problemen[0])
+
+    def test_twee_soorten_falen_ook(self):
+        problemen = route.controleer(["soort:github", "soort:routekaart"], [], ["AGENTS.md"])
+        self.assertEqual(len(problemen), 1)
+        self.assertIn("Meer dan één soort:-label", problemen[0])
+
+    def test_het_issue_wint_van_de_pull_request(self):
+        # Dezelfde voorrang als het bord: staat het soort op het issue, dan is
+        # een afwijkend label op de PR niet ineens een tweede soort.
+        self.assertEqual(route.controleer(["soort:github"], ["soort:routekaart"], ["AGENTS.md"]), [])
+
+
+class SneltreinRegel(unittest.TestCase):
+    def test_sneltrein_met_alleen_tekst_mag(self):
+        problemen = route.controleer(
+            ["route:sneltrein", "soort:github"], [],
+            ["AGENTS.md", ".github/PULL_REQUEST_TEMPLATE.md"],
+        )
+        self.assertEqual(problemen, [])
+
+    def test_sneltrein_die_de_pagina_raakt_faalt(self):
+        problemen = route.controleer(["route:sneltrein", "soort:routekaart"], [], ["index.html"])
+        self.assertEqual(len(problemen), 1)
+        self.assertIn("verandert gedrag", problemen[0])
+        self.assertIn("index.html", problemen[0])
+
+    def test_sneltrein_die_een_werkschema_raakt_faalt(self):
+        problemen = route.controleer(
+            ["route:sneltrein", "soort:github"], [],
+            ["AGENTS.md", ".github/workflows/quality.yml"],
+        )
+        self.assertEqual(len(problemen), 1)
+        self.assertIn(".github/workflows/quality.yml", problemen[0])
+
+    def test_sneltrein_die_een_test_raakt_faalt(self):
+        problemen = route.controleer(["route:sneltrein", "soort:github"], [], ["test/smoketest.js"])
+        self.assertEqual(len(problemen), 1)
+
+    def test_sneltrein_die_een_script_raakt_faalt(self):
+        problemen = route.controleer(
+            ["route:sneltrein", "soort:github"], [], [".github/scripts/route-controle.py"],
+        )
+        self.assertEqual(len(problemen), 1)
+
+    def test_dezelfde_wijziging_mag_wel_via_de_bouwroute(self):
+        # Zonder het sneltreinlabel is index.html volstrekt normaal werk.
+        self.assertEqual(route.controleer(["soort:routekaart"], [], ["index.html"]), [])
+
+    def test_beide_regels_kunnen_samen_falen(self):
+        problemen = route.controleer(["route:sneltrein"], [], ["index.html"])
+        self.assertEqual(len(problemen), 2)
+
+
+class FakeGitHub:
+    """Vervangt de echte GitHub-aanroepen; geeft terug wat de test wil zien."""
+
+    def __init__(self, bestanden, issue_labels=None):
+        self._bestanden = bestanden
+        self._issue_labels = issue_labels or []
+
+    def bestanden(self, nummer):
+        return list(self._bestanden)
+
+    def issue_labels(self, nummer):
+        return list(self._issue_labels)
+
+
+class Uitvoering(unittest.TestCase):
+    """De hele stap zoals hij in het werkschema draait, zonder netwerk."""
+
+    def _draai(self, payload, *, bestanden, issue_labels=None, token="x"):
+        with tempfile.NamedTemporaryFile("w", suffix=".json", delete=False, encoding="utf-8") as bestand:
+            json.dump(payload, bestand)
+            pad = bestand.name
+        omgeving = {"GITHUB_EVENT_PATH": pad}
+        if token is not None:
+            omgeving["GITHUB_TOKEN"] = token
+        try:
+            with patch.dict(os.environ, omgeving, clear=True), \
+                 patch.object(route, "GitHub", lambda *a, **k: FakeGitHub(bestanden, issue_labels)):
+                return route.main()
+        finally:
+            os.unlink(pad)
+
+    @staticmethod
+    def _payload(labels, *, nummer=1, titel="iets", tekst=""):
+        return {
+            "pull_request": {
+                "number": nummer,
+                "title": titel,
+                "body": tekst,
+                "labels": [{"name": naam} for naam in labels],
+            },
+            "repository": {"full_name": "lxdg-technologies/git-routekaart-demo"},
+        }
+
+    def test_een_kloppende_pull_request_slaagt(self):
+        code = self._draai(self._payload(["soort:github"]), bestanden=["AGENTS.md"])
+        self.assertEqual(code, 0)
+
+    def test_een_sneltrein_die_gedrag_raakt_faalt(self):
+        code = self._draai(
+            self._payload(["route:sneltrein", "soort:github"]), bestanden=["index.html"],
+        )
+        self.assertEqual(code, 1)
+
+    def test_geen_bestanden_is_geen_groen(self):
+        # De belangrijkste test: als de controle zijn gegevens niet kan
+        # vaststellen, mag hij niet slagen. Een pull request zonder gewijzigde
+        # bestanden bestaat niet.
+        code = self._draai(self._payload(["soort:github"]), bestanden=[])
+        self.assertEqual(code, 1)
+
+    def test_zonder_token_is_geen_groen(self):
+        code = self._draai(self._payload(["soort:github"]), bestanden=["AGENTS.md"], token=None)
+        self.assertEqual(code, 1)
+
+    def test_zonder_gebeurtenis_is_geen_groen(self):
+        with patch.dict(os.environ, {"GITHUB_TOKEN": "x"}, clear=True):
+            self.assertEqual(route.main(), 1)
+
+    def test_een_gebeurtenis_zonder_pull_request_is_geen_groen(self):
+        code = self._draai({"repository": {"full_name": "a/b"}}, bestanden=["AGENTS.md"])
+        self.assertEqual(code, 1)
+
+    def test_het_soort_mag_van_het_gekoppelde_issue_komen(self):
+        code = self._draai(
+            self._payload([], tekst="Fixes #164"),
+            bestanden=["index.html"], issue_labels=["soort:github"],
+        )
+        self.assertEqual(code, 0)
+
+
+class Werkschema(unittest.TestCase):
+    """De controle moet echt aanstaan, niet alleen bestaan."""
+
+    def setUp(self):
+        self.quality = (ROOT / ".github/workflows/quality.yml").read_text(encoding="utf-8")
+
+    def test_de_tests_draaien_in_de_verplichte_poort(self):
+        self.assertIn("python3 test/route-controle.py", self.quality)
+
+    def test_de_controle_zelf_draait_in_de_verplichte_poort(self):
+        self.assertIn("python3 .github/scripts/route-controle.py", self.quality)
+
+    def test_de_controle_draait_alleen_bij_een_pull_request(self):
+        # Op een push naar main is er geen pull request; zonder deze voorwaarde
+        # zou de poort daar altijd rood staan.
+        stap = self.quality.split("Routecontrole op deze pull request", 1)[1]
+        stap = stap.split("- name:", 1)[0]
+        self.assertIn("github.event_name == 'pull_request'", stap)
+        self.assertIn("GITHUB_TOKEN", stap)
+
+    def test_de_poort_draait_op_pull_requests_naar_main(self):
+        self.assertIn("pull_request:", self.quality)
+        self.assertIn("branches: [main]", self.quality)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Voor Rob — in gewone taal

**Wat verandert er voor jou?** Twee afspraken die tot nu toe onthouden moesten worden, worden nu automatisch gecontroleerd bij elke pull request:

1. Elke pull request moet zeggen wát voor werk het is (`soort:routekaart` of `soort:github`). Zonder dat label zet het bord de kaart in de verkeerde baan — en daar komt hij nooit meer uit.
2. Een pull request met `route:sneltrein` (door Claude geschreven, zonder Coder en Reviewer) mag niets raken dat gedrag verandert. Dus geen `index.html`, geen tests, geen werkschema's. Daarvoor is er de bouwroute met een onafhankelijke beoordeling.

**Hoe test je het?** De poort bewijst zichzelf hier meteen. PR #168 mist een `soort:`-label en gaat daardoor rood; zodra dat label erop staat wordt hij groen. Zonder dat je iets hoeft te installeren of te klikken.

Je hoeft **geen repo-instelling te wijzigen** — de controle hangt onder `quality`, en die was al verplicht.

## Wat verandert er (technisch)

- `.github/scripts/route-controle.py` — de logica; leest labels uit de gebeurtenis, gewijzigde bestanden en de labels van het gekoppelde issue via de API.
- `test/route-controle.py` — 31 gedragstests, elke regel zowel groen als rood.
- `.github/workflows/quality.yml` — twee stappen erbij; `permissions` expliciet en alleen-lezen; `labeled`/`unlabeled` toegevoegd aan de triggers zodat een ontbrekend label zonder lege commit te repareren is.

De labelbepaling volgt **dezelfde voorrang als het bord** (gekoppeld issue eerst, dan de PR) en dezelfde koppelingsregex, zodat controle en bord niet van mening kunnen verschillen.

## Controle

- `python3 test/route-controle.py` — 31 van 31 geslaagd.
- **Sabotagetest**, drie keer: de logica bewust stukgemaakt en gecontroleerd dat de tests dan echt falen — `raakt_gedrag` altijd nee (11 fouten), soort-labelregel uitgeschakeld (2 fouten), lege bestandenlijst mag slagen (1 fout). Na herstel weer groen. Een controle die niet rood kan worden bewijst niets, en dat is hier eerder misgegaan.
- **Droogtest tegen de echte openstaande pull requests**, vóór het pushen: #167 groen, #161 groen (de bouwroute wordt dus niet gehinderd), #166 en #168 rood op het ontbrekende `soort:`-label — precies wat het hoort te vinden.
- De controle weigert groen te worden zonder token, zonder gebeurtenis, of met een lege bestandenlijst.

## Raakt

`.github/scripts/route-controle.py` (nieuw), `test/route-controle.py` (nieuw), `.github/workflows/quality.yml`.

## NIET in scope

- De sneltrein-route als voorbeeld op de kaart in de simulatie zetten — aparte, grotere wijziging.
- `review-guard` verplicht maken; dat blijft een repo-instelling van Rob.
- De kaarten van al gemergde pull requests rechtzetten.
