### PR TITLE
PROEFRIT — laat de routecontrole afgaan (niet mergen)

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -63,3 +63,6 @@ jobs:
         run: python3 .github/scripts/route-controle.py
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+# Proefrit: deze regel is toegevoegd om de routecontrole te laten afgaan.
+# Deze pull request hoort NIET gemerged te worden — sluiten na de proefrit.


### PR DESCRIPTION
## Voor Rob — in gewone taal

**Dit is geen echte wijziging.** Deze pull request bestaat om je te laten zíen dat de nieuwe poort werkt. Hij mag nooit gemerged worden — sluit hem als je klaar bent.

### Wat je hier moet zien

Deze pull request draagt het label `route:sneltrein` (= door Claude gemaakt, zonder Coder en Reviewer) **en** raakt een werkschema. Dat mag niet samen: iets wat gedrag verandert hoort langs een onafhankelijke beoordeling.

**De controle hoort dus rood te staan.**

### Doe dit zelf, duurt twee minuten

1. **Kijk onderaan deze pagina bij de controles.** Klik op `Details` achter **quality**.
2. Zoek in de lijst de stap **"Routecontrole op deze pull request"**. Die is rood, en er staat waarom:
   > Deze pull request draagt route:sneltrein maar verandert gedrag: .github/workflows/quality.yml
3. **Haal nu het label `route:sneltrein` weg** (rechterkolom, bij Labels).
4. Wacht ongeveer twee minuten. De controle draait automatisch opnieuw — daar hoef je niets voor te doen.
5. **Nu staat hij groen.** Dezelfde wijziging, ander label: zonder de sneltrein is een werkschema wijzigen volstrekt normaal werk.
6. **Sluit deze pull request** met de knop *Close pull request*. Niet mergen.

### Wat je hiermee weet

- De poort kan echt rood worden. Een controle die dat niet kan, bewijst niets.
- Hij legt in gewone taal uit wát er mis is en wat je eraan doet.
- Het label bepaalt de route, en de route bepaalt wat mag.

---

## Technisch

Voegt twee commentaarregels toe aan `.github/workflows/quality.yml`. Verandert geen gedrag; bestaat uitsluitend om de controle van #169 te demonstreren.

Zie ook [#170](https://github.com/lxdg-technologies/git-routekaart-demo/issues/170) over de merge-ketting, en `PROEFRITTEN.md` voor de andere proefritten.
