### PR TITLE
Kies tussen GitHub en de nieuwe Git API

### DIFF
--- a/index.html
+++ b/index.html
@@ -114,6 +114,8 @@
   .repository-heading a { color: var(--accent); font-family: var(--mono); font-weight: 700; text-decoration: none; }
   .repository-heading a:hover, .repository-heading a:focus-visible { text-decoration: underline; }
   .repository-actions { display: flex; align-items: center; justify-content: flex-end; gap: .6rem; flex-wrap: wrap; color: var(--ink-soft); font-size: .75rem; }
+  .repository-backend { display: flex; align-items: center; gap: .35rem; }
+  .repository-backend select { border: 1px solid var(--line); border-radius: 7px; background: var(--chip-bg); color: var(--ink); padding: .3rem .45rem; font: inherit; }
   .repository-refresh { border: 1px solid var(--line); border-radius: 7px; background: var(--chip-bg); color: var(--ink); padding: .3rem .55rem; cursor: pointer; font: inherit; }
   .repository-refresh:disabled { cursor: wait; opacity: .6; }
   .repository-status { min-height: 1.35em; margin: .7rem 0; padding: .5rem .65rem; border: 1px solid var(--line); border-radius: 8px; color: var(--ink-soft); font-size: .82rem; }
@@ -569,6 +571,12 @@
       <p><a id="repository-link" href="https://github.com/lxdg-technologies/git-routekaart-demo" target="_blank" rel="noreferrer">lxdg-technologies/git-routekaart-demo ↗</a></p>
     </div>
     <div class="repository-actions">
+      <label class="repository-backend" for="repository-backend">Databron
+        <select id="repository-backend">
+          <option value="github">GitHub API (huidig)</option>
+          <option value="gitapi">Git API (nieuw)</option>
+        </select>
+      </label>
       <span id="repository-updated">Nog niet bijgewerkt</span>
       <button type="button" class="repository-refresh" id="repository-refresh">↻ Vernieuwen</button>
     </div>
@@ -715,9 +723,36 @@
 
   /* ==== SECTIE: REPOSITORY ==== */
   const REPOSITORY_FULL_NAME = "lxdg-technologies/git-routekaart-demo";
-  const REPOSITORY_API_ROOT = `https://api.github.com/repos/${REPOSITORY_FULL_NAME}`;
-  const REPOSITORY_CACHE_KEY = `git-routekaart-repository-v1:${REPOSITORY_FULL_NAME}`;
+  const REPOSITORY_BACKENDS = {
+    github: {
+      name: "GitHub API",
+      apiRoot: `https://api.github.com/repos/${REPOSITORY_FULL_NAME}`,
+      aggregateDashboard: false,
+    },
+    gitapi: {
+      name: "gitapi.lxdg.tech",
+      apiRoot: `https://gitapi.lxdg.tech/api/v1/repos/${REPOSITORY_FULL_NAME}`,
+      aggregateDashboard: true,
+    },
+  };
   const REPOSITORY_CACHE_TTL = 5 * 60 * 1000;
+
+  function selectedRepositoryBackend() {
+    const selected = el("repository-backend")?.value;
+    return Object.prototype.hasOwnProperty.call(REPOSITORY_BACKENDS, selected) ? selected : "github";
+  }
+  function repositoryBackend() {
+    return REPOSITORY_BACKENDS[selectedRepositoryBackend()];
+  }
+  function repositoryCacheKey(backendName = selectedRepositoryBackend()) {
+    return `git-routekaart-repository-v1:${backendName}:${REPOSITORY_FULL_NAME}`;
+  }
+  function repositoryReleaseHistoryUrl() {
+    return `${repositoryBackend().apiRoot}/releases?per_page=5`;
+  }
+  function repositoryCheckRunsUrl(sha) {
+    return `${repositoryBackend().apiRoot}/commits/${encodeURIComponent(sha)}/check-runs?per_page=100`;
+  }
 
   function repositoryUsesSimulatedData() {
     return typeof location !== "undefined" && /\/dev\/pr-\d+(?:\/|$)/.test(location.pathname || "");
@@ -774,9 +809,9 @@
     if (Number.isNaN(date.getTime())) return "datum onbekend";
     return new Intl.DateTimeFormat("nl-NL", { day: "2-digit", month: "short", year: "numeric" }).format(date);
   }
-  function repositoryCacheRead() {
+  function repositoryCacheRead(backendName) {
     try {
-      const cached = sessionStorage.getItem(REPOSITORY_CACHE_KEY);
+      const cached = sessionStorage.getItem(repositoryCacheKey(backendName));
       if (!cached) return null;
       const parsed = JSON.parse(cached);
       return parsed && Date.now() - parsed.savedAt < REPOSITORY_CACHE_TTL ? parsed : null;
@@ -784,22 +819,21 @@
       return null;
     }
   }
-  function repositoryCacheWrite(snapshot) {
+  function repositoryCacheWrite(snapshot, backendName) {
     try {
-      sessionStorage.setItem(REPOSITORY_CACHE_KEY, JSON.stringify(snapshot));
+      sessionStorage.setItem(repositoryCacheKey(backendName), JSON.stringify(snapshot));
     } catch (error) {
       // De pagina blijft werken als opslag is uitgeschakeld of vol is.
     }
   }
-  async function fetchRepositoryJson(url) {
+  async function fetchRepositoryJson(url, backendName = selectedRepositoryBackend()) {
+    const headers = { Accept: "application/vnd.github+json" };
+    if (backendName === "github") headers["X-GitHub-Api-Version"] = "2022-11-28";
     const response = await fetch(url, {
-      headers: {
-        Accept: "application/vnd.github+json",
-        "X-GitHub-Api-Version": "2022-11-28",
-      },
+      headers,
     });
     if (!response.ok) {
-      const error = new Error(`GitHub API: ${response.status}`);
+      const error = new Error(`Repositorygegevens: ${response.status}`);
       error.status = response.status;
       throw error;
     }
@@ -813,7 +847,7 @@
     }
     list.innerHTML = items.slice(0, 8).map(renderer).join("");
   }
-  function renderRepositoryDashboard(snapshot, source) {
+  function renderRepositoryDashboard(snapshot, source, backendName = selectedRepositoryBackend()) {
     const { repository, commits, branches, issues, prs } = snapshot;
     const repositoryUrl = `https://github.com/${REPOSITORY_FULL_NAME}`;
     const simulated = source === "simulated";
@@ -824,7 +858,7 @@
     el("repository-status").className = "repository-status";
     el("repository-status").textContent = simulated
       ? "Gesimuleerde GitHub-gegevens · ontwikkelomgeving · geen verbinding met de GitHub API"
-      : `Rechtstreeks uit GitHub · publieke gegevens · hoofdbranch ${repository.default_branch || "main"}${source === "cache" ? " · tijdelijk uit browsercache" : ""}`;
+      : `${backendName === "gitapi" ? "Via gitapi.lxdg.tech" : "Rechtstreeks uit GitHub"} · publieke gegevens · hoofdbranch ${repository.default_branch || "main"}${source === "cache" ? " · tijdelijk uit browsercache" : ""}`;
     el("repository-source-label").textContent = simulated
       ? "Oefengegevens: branches, commits, issues, pull requests en dashboardversie zijn voorbeelden."
       : "Echte GitHub-gegevens: branches, commits, issues, pull requests en dashboardversie.";
@@ -886,43 +920,59 @@
   async function loadRepositoryDashboard(force = false) {
     const refresh = el("repository-refresh");
     const status = el("repository-status");
+    const backendName = selectedRepositoryBackend();
+    const backend = REPOSITORY_BACKENDS[backendName];
     refresh.disabled = true;
     status.className = "repository-status";
     status.textContent = force ? "GitHub-gegevens worden opnieuw opgehaald…" : "GitHub-gegevens worden opgehaald…";
-    const cached = repositoryCacheRead();
+    const cached = repositoryCacheRead(backendName);
     if (repositoryUsesSimulatedData()) {
-      renderRepositoryDashboard(simulatedRepositorySnapshot(), "simulated");
+      renderRepositoryDashboard(simulatedRepositorySnapshot(), "simulated", backendName);
       refresh.disabled = false;
       return;
     }
     if (!force) {
       if (cached) {
-        renderRepositoryDashboard(cached, "cache");
+        renderRepositoryDashboard(cached, "cache", backendName);
         refresh.disabled = false;
         return;
       }
     }
     try {
-      const repository = await fetchRepositoryJson(REPOSITORY_API_ROOT);
-      const defaultBranch = repository.default_branch || "main";
-      const [commits, branches, rawIssues, prs] = await Promise.all([
-        fetchRepositoryJson(`${REPOSITORY_API_ROOT}/commits?sha=${encodeURIComponent(defaultBranch)}&per_page=100`),
-        fetchRepositoryJson(`${REPOSITORY_API_ROOT}/branches?per_page=100`),
-        fetchRepositoryJson(`${REPOSITORY_API_ROOT}/issues?state=all&sort=updated&per_page=100`),
-        fetchRepositoryJson(`${REPOSITORY_API_ROOT}/pulls?state=all&sort=updated&direction=desc&per_page=100`),
-      ]);
-      const snapshot = {
-        savedAt: Date.now(),
-        repository,
-        commits: Array.isArray(commits) ? commits : [],
-        branches: Array.isArray(branches) ? branches : [],
-        issues: Array.isArray(rawIssues) ? rawIssues.filter(issue => !issue.pull_request) : [],
-        prs: Array.isArray(prs) ? prs : [],
-      };
-      repositoryCacheWrite(snapshot);
-      renderRepositoryDashboard(snapshot, "api");
+      let snapshot;
+      if (backend.aggregateDashboard) {
+        const aggregate = await fetchRepositoryJson(`${backend.apiRoot}/dashboard`, backendName);
+        if (!aggregate || typeof aggregate !== "object" || !aggregate.repository) throw new Error("Repositorydashboard ontbreekt");
+        snapshot = {
+          savedAt: Number.isFinite(aggregate.savedAt) ? aggregate.savedAt : Date.now(),
+          repository: aggregate.repository,
+          commits: Array.isArray(aggregate.commits) ? aggregate.commits : [],
+          branches: Array.isArray(aggregate.branches) ? aggregate.branches : [],
+          issues: Array.isArray(aggregate.issues) ? aggregate.issues : [],
+          prs: Array.isArray(aggregate.prs) ? aggregate.prs : [],
+        };
+      } else {
+        const repository = await fetchRepositoryJson(backend.apiRoot, backendName);
+        const defaultBranch = repository.default_branch || "main";
+        const [commits, branches, rawIssues, prs] = await Promise.all([
+          fetchRepositoryJson(`${backend.apiRoot}/commits?sha=${encodeURIComponent(defaultBranch)}&per_page=100`, backendName),
+          fetchRepositoryJson(`${backend.apiRoot}/branches?per_page=100`, backendName),
+          fetchRepositoryJson(`${backend.apiRoot}/issues?state=all&sort=updated&per_page=100`, backendName),
+          fetchRepositoryJson(`${backend.apiRoot}/pulls?state=all&sort=updated&direction=desc&per_page=100`, backendName),
+        ]);
+        snapshot = {
+          savedAt: Date.now(),
+          repository,
+          commits: Array.isArray(commits) ? commits : [],
+          branches: Array.isArray(branches) ? branches : [],
+          issues: Array.isArray(rawIssues) ? rawIssues.filter(issue => !issue.pull_request) : [],
+          prs: Array.isArray(prs) ? prs : [],
+        };
+      }
+      repositoryCacheWrite(snapshot, backendName);
+      renderRepositoryDashboard(snapshot, "api", backendName);
     } catch (error) {
-      if (cached) renderRepositoryDashboard(cached, "cache");
+      if (cached) renderRepositoryDashboard(cached, "cache", backendName);
       renderRepositoryUnavailable(Boolean(cached));
     } finally {
       refresh.disabled = false;
@@ -931,7 +981,6 @@
 
   /* ==== SECTIE: RELEASE-BADGE ==== */
   const VERSION_FILE_URL = "version.json";
-  const RELEASE_HISTORY_API_URL = `${REPOSITORY_API_ROOT}/releases?per_page=5`;
   function getReleaseEnvironment() {
     return typeof location !== "undefined"
       ? (location.protocol === "file:" || ["localhost", "127.0.0.1"].includes(location.hostname) || repositoryUsesSimulatedData()
@@ -1007,7 +1056,7 @@
       return;
     }
     try {
-      const response = await fetch(RELEASE_HISTORY_API_URL, { headers: { Accept: "application/vnd.github+json" } });
+      const response = await fetch(repositoryReleaseHistoryUrl(), { headers: { Accept: "application/vnd.github+json" } });
       if (!response.ok) throw new Error(`GitHub Releases API: ${response.status}`);
       const releases = await response.json();
       if (!Array.isArray(releases)) throw new Error("GitHub-releasegeschiedenis is geen lijst");
@@ -1102,7 +1151,7 @@
       return;
     }
     try {
-      const response = await fetch(`${REPOSITORY_API_ROOT}/commits/${encodeURIComponent(testSha)}/check-runs?per_page=100`, { headers: { Accept: "application/vnd.github+json" } });
+      const response = await fetch(repositoryCheckRunsUrl(testSha), { headers: { Accept: "application/vnd.github+json" } });
       if (!response.ok) throw new Error(`GitHub-controles: ${response.status}`);
       const data = await response.json();
       const checks = Array.isArray(data.check_runs) ? data.check_runs : [];
@@ -1375,7 +1424,7 @@
       const testSha = versionResult.build.sha;
       const testVersion = versionResult.build.version;
       if (!testSha || testData?.environment !== "test" || testData.version !== testVersion || testData.sha !== testSha || !liveData?.version) throw new Error("De Test-publicatie en de versiegegevens komen niet aantoonbaar overeen.");
-      const checksResponse = await fetch(`${REPOSITORY_API_ROOT}/commits/${encodeURIComponent(testSha)}/check-runs?per_page=100`, { headers: { Accept: "application/vnd.github+json" } });
+      const checksResponse = await fetch(repositoryCheckRunsUrl(testSha), { headers: { Accept: "application/vnd.github+json" } });
       if (!checksResponse.ok) throw new Error("De verplichte checks konden niet worden gelezen.");
       const checksData = await checksResponse.json();
       const checks = Array.isArray(checksData.check_runs) ? checksData.check_runs : [];
@@ -2122,6 +2171,11 @@
   el("btn-rollback").onclick = rollback;
   el("btn-clear-start").onclick = clearStart;
   applyPromotionVisibility();
+  el("repository-backend").onchange = () => {
+    el("release-history").dataset.historyLoaded = "false";
+    loadRepositoryDashboard();
+    if (el("release-history").open) loadReleaseHistory();
+  };
   el("repository-refresh").onclick = () => loadRepositoryDashboard(true);
   el("reset").onclick = () => { el("log").innerHTML = ""; init(); log("Opnieuw begonnen", "Schone kaart: alleen main met twee commits, test en live allebei op v0.1.0."); };
   window.selectStart = selectStart; // aangeroepen vanuit de inline SVG (onclick-attribuut)

--- a/test/checks/repository-dashboard.js
+++ b/test/checks/repository-dashboard.js
@@ -25,6 +25,23 @@ module.exports = async function repositoryDashboard({ assert, byIdMap, fetchCall
   assert(!byIdMap["repository-status"].className.includes("error") && byIdMap["repository-status"].innerHTML.includes("Bekijk de repository op GitHub"), "mislukte repository-aanvraag toont een neutrale GitHub-link");
   assert(!byIdMap["repository-commits"].innerHTML.includes("Laden…") && byIdMap["repository-commits"].innerHTML === cachedCommit, "repositorydashboard behoudt bestaande cache bij een mislukte vernieuwing");
 
+  setFetchMode("version");
+  byIdMap["release-history"].open = false;
+  const callsBeforeBackendSwitch = fetchCalls.length;
+  byIdMap["repository-backend"].value = "gitapi";
+  byIdMap["repository-backend"].onchange();
+  await flush(); await flush(); await flush();
+  const backendSwitchCalls = fetchCalls.slice(callsBeforeBackendSwitch);
+  assert(backendSwitchCalls.filter(url => url === "https://gitapi.lxdg.tech/api/v1/repos/lxdg-technologies/git-routekaart-demo/dashboard").length === 1 && !backendSwitchCalls.some(url => url.includes("/branches?")), "nieuwe backend haalt het samengevoegde dashboard met één API-call op");
+  assert(byIdMap["repository-status"].textContent.includes("Via gitapi.lxdg.tech") && byIdMap["repository-commits"].innerHTML.includes("via nieuwe Git API"), "dropdown toont en rendert gegevens uit de nieuwe backend");
+
+  setFetchMode("history");
+  byIdMap["release-history"].open = true;
+  byIdMap["release-history"].dataset.historyLoaded = "false";
+  byIdMap["release-history"].ontoggle();
+  await flush(); await flush();
+  assert(fetchCalls.some(url => url === "https://gitapi.lxdg.tech/api/v1/repos/lxdg-technologies/git-routekaart-demo/releases?per_page=5"), "releasehistorie gebruikt de gekozen nieuwe backend");
+
   const callsBeforeDevelopment = fetchCalls.length;
   setFetchMode("version");
   global.location = { protocol: "https:", hostname: "lxdg-technologies.github.io", pathname: "/git-routekaart-demo/dev/pr-51/" };

--- a/test/smoketest.js
+++ b/test/smoketest.js
@@ -44,6 +44,8 @@ const ids = ["map-scroll", "legend", "begrippen-lijst", "commandoreferentie-lijs
 for (const id of ids) byIdMap[id] = makeEl("div");
 for (const id of ["btn-live-overlay", "btn-close-live-overlay", "btn-promotion-green", "btn-promotion-red", "btn-promotion-recover", "btn-promotion-live", "btn-review-approve", "btn-review-reject", "btn-close-review-guide", "btn-review-guide-back", "btn-review-guide-next"]) byIdMap[id] = makeEl("button");
 for (const id of ["env-dev-box", "env-test-box", "env-live-box"]) byIdMap[id] = makeEl("button");
+byIdMap["repository-backend"] = makeEl("select");
+byIdMap["repository-backend"].value = "github";
 byIdMap["btn-live-overlay"].textContent = "Naar live zetten";
 byIdMap["live-promotion-overlay"].hidden = true;
 byIdMap["live-promotion-overlay"].setAttribute("aria-hidden", "true");
@@ -55,7 +57,23 @@ const fetchCalls = [];
 const response = (payload, status = 200) => ({ ok: status >= 200 && status < 300, status, async json() { return payload; } });
 global.fetch = async url => {
   fetchCalls.push(String(url));
-  if (fetchMode === "repository-error" && String(url).startsWith("https://api.github.com/repos/lxdg-technologies/git-routekaart-demo")) return response({}, 503);
+  if (fetchMode === "repository-error" && ["https://api.github.com/repos/lxdg-technologies/git-routekaart-demo", "https://gitapi.lxdg.tech/api/v1/repos/lxdg-technologies/git-routekaart-demo"].some(root => String(url).startsWith(root))) return response({}, 503);
+  if (String(url) === "https://gitapi.lxdg.tech/api/v1/repos/lxdg-technologies/git-routekaart-demo/dashboard") return response({
+    savedAt: Date.now(),
+    repository: { full_name: "lxdg-technologies/git-routekaart-demo", default_branch: "main", html_url: "https://github.com/lxdg-technologies/git-routekaart-demo" },
+    commits: [
+      { sha: "api123456789", html_url: "https://github.com/lxdg-technologies/git-routekaart-demo/commit/api1234", commit: { message: "feat: via nieuwe Git API", author: { date: "2026-08-08T10:00:00Z" } } },
+    ],
+    branches: [
+      { name: "main", protected: true, commit: { sha: "api123456789" } },
+    ],
+    issues: [
+      { number: 8, title: "Issue via nieuwe Git API", state: "open", updated_at: "2026-08-08T10:00:00Z", html_url: "https://github.com/lxdg-technologies/git-routekaart-demo/issues/8" },
+    ],
+    prs: [
+      { number: 9, title: "PR via nieuwe Git API", state: "open", merged_at: null, html_url: "https://github.com/lxdg-technologies/git-routekaart-demo/pull/9", head: { ref: "feat/git-api" }, base: { ref: "main" } },
+    ],
+  });
   if (String(url) === "https://api.github.com/repos/lxdg-technologies/git-routekaart-demo") return response({
     full_name: "lxdg-technologies/git-routekaart-demo", default_branch: "main", html_url: "https://github.com/lxdg-technologies/git-routekaart-demo",
   });
@@ -216,6 +234,7 @@ const delen = [
   await loadTestStatus("checks-green");
   byIdMap["test-live-check"].onclick(); await flush();
   assert(byIdMap["test-live-status"].classList.contains("is-safe") && byIdMap["test-live-status-text"].textContent === "✓ Veilig om live te zetten" && byIdMap["test-live-condition-checks"].textContent.includes("Alle verplichte controles zijn geslaagd"), "groene controle toont in één regel dat Test veilig live kan");
+  assert(fetchCalls.some(url => url === "https://gitapi.lxdg.tech/api/v1/repos/lxdg-technologies/git-routekaart-demo/commits/abc1234/check-runs?per_page=100"), "veiligheidscontrole gebruikt de gekozen nieuwe backend");
   assert(byIdMap["test-live-promote-link"].hidden === false && byIdMap["test-live-condition-human"].textContent.includes("mens"), "alleen groen toont de knop voor handmatige promotie en menselijke bevestiging");
   byIdMap["btn-live-overlay"].onclick(); await flush();
   assert(byIdMap["promotion-modes"].hidden === true && byIdMap["promotion-description"].textContent.includes("echte Test-gegevens"), "de Test-overlay gebruikt geen voorbeeldkeuze en meldt echte Test-gegevens");


### PR DESCRIPTION
## Wat verandert er voor de bezoeker?

Boven het echte repositorydashboard staat een keuzelijst **Databron**. De bestaande rechtstreekse GitHub API blijft de beginstand. Een bezoeker kan daarnaast de nieuwe Git API kiezen; het dashboard, de releasehistorie en de veiligheidscontrole voor Test gebruiken daarna dezelfde gekozen bron. De ontwikkelomgeving blijft vaste oefengegevens gebruiken en verstuurt geen externe API-verzoeken.

## Issue

Fixes #194

## Niet in scope

- De metrokaartsimulatie en missies zijn niet gewijzigd.
- Er zijn geen schrijfacties, logins of tokens aan browsercode toegevoegd.
- De serverinstelling die GitHub-integratie activeert wordt in de API-deployment geregeld, niet in deze frontend-PR.

## Waar is het te zien?

Volledig adres: https://lxdg-technologies.github.io/git-routekaart-demo/dev/pr-195/

De ontwikkelomgeving toont de keuzelijst met voorspelbare oefengegevens. De echte koppeling is na merge op Test zichtbaar; `GITHUB_REPOSITORY=lxdg-technologies/git-routekaart-demo` is op de API-server geactiveerd en de drie gebruikte routes zijn via het publieke HTTPS-adres gecontroleerd.

## In welke stand heb je het geprobeerd?

- Verse pagina, direct na openen: **GitHub API (huidig)** is geselecteerd.
- Daarna **Git API (nieuw)** gekozen: het samengevoegde dashboard wordt gebruikt en de getoonde gegevens blijven intact.
- Releasehistorie geopend na de wissel: de gekozen nieuwe backend wordt gebruikt.
- Veiligheidscontrole op Test: de check-runs-URL volgt de gekozen backend.
- Ontwikkelomgeving van een pull request: blijft oefengegevens tonen en doet geen externe fetch.

**Wat te checken:** open de ontwikkelomgeving, controleer dat **Databron** standaard op **GitHub API (huidig)** staat, kies **Git API (nieuw)** en controleer dat het repositorydashboard zichtbaar blijft.

## Controles

- [x] `node test/smoketest.js` — eindregel: `ALLE 175 CHECKS GESLAAGD`.
- [x] `bash test/versioning.sh` — eindregel: `Versiebepaling geslaagd: v1.2.0, v1.2.1, v1.2.2, v2.0.0, v2.0.1`.
- [x] `bash test/deployment-queue.sh` — eindregel: `ALLE DEPLOYMENTRIJ-CHECKS GESLAAGD`.
- [x] `python3 test/projectbord.py` — `Ran 36 tests ... OK`.
- [x] `python3 test/route-controle.py` — `Ran 38 tests ... OK`.
- [ ] `bash test/omgevingsbalk.sh` en `node test/browser-quality.js` — lokaal niet uitvoerbaar doordat macOS `awk` de bestaande multiline invoer weigert; de Ubuntu quality-workflow moet deze twee controles nog bevestigen.
- [x] Live API-integratie — dashboard `200` met 73 branches en 14 open issues; releases `200` met 5 resultaten; check-runs `200` met 6 resultaten. Alle drie via `https://gitapi.lxdg.tech` en met de GitHub Pages-origin gecontroleerd.
