### PR TITLE
Het opruimen van een gesloten voorstel vond zijn eigen script niet

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -158,6 +158,16 @@ jobs:
       group: gh-pages-development-pr-${{ github.event.number }}
       cancel-in-progress: false
     steps:
+      # Deze taak heeft de broncode nodig, want het publiceren gaat via een
+      # script dat daar staat. Zonder deze stap valt het opruimen om met
+      # "No such file or directory" — en dan blijft de proefomgeving van een
+      # gesloten voorstel voorgoed staan. Zie #209.
+      - name: Checkout de broncode van main
+        uses: actions/checkout@v6
+        with:
+          ref: main
+          path: source
+
       - name: Checkout deployment branch
         uses: actions/checkout@v6
         with:

--- a/test/deployment-queue.sh
+++ b/test/deployment-queue.sh
@@ -73,3 +73,21 @@ grep -Fq 'Push afgewezen' "$tmp/test.log"
 printf 'ok  : gelijktijdige publicaties behouden beide omgevingen na een botsing\n'
 printf 'ok  : onafhankelijke publicatie blokkeert niet op een trage publicatie\n'
 printf '\nALLE DEPLOYMENTRIJ-CHECKS GESLAAGD\n'
+
+# Elke taak die het publiceerscript aanroept, moet de broncode ook echt hebben.
+# Op 29-08-2026 miste die in de opruimtaak: het opruimen van een gesloten
+# voorstel viel om met "No such file or directory", en de proefomgeving bleef
+# staan. Zie #209.
+for workflow in "$root/.github/workflows/deploy-dev.yml" "$root/.github/workflows/deploy-test.yml"; do
+  ontbreekt="$(awk '
+    /^  [a-z-]+:$/ { taak=$1; heeft[taak]=heeft[taak] }
+    /path: source/ { bron[taak]=1 }
+    /publiceer-omgeving\.sh/ { gebruikt[taak]=1 }
+    END { for (t in gebruikt) if (!(t in bron)) print t }
+  ' "$workflow")"
+  if [ -n "$ontbreekt" ]; then
+    printf 'FAIL: %s roept het publiceerscript aan zonder de broncode: %s\n' "${workflow##*/}" "$ontbreekt" >&2
+    exit 1
+  fi
+  printf 'ok  : elke taak in %s die publiceert heeft de broncode\n' "${workflow##*/}"
+done


### PR DESCRIPTION
Rob kreeg vlak na het samenvoegen van #208 een foutmelding. Dit is hem.

## Wat er misging

```
bash: ../source/.github/scripts/publiceer-omgeving.sh: No such file or directory
Process completed with exit code 127
```

#205 verving vier kopieën van de publiceerlus door één gedeeld script. Drie van de vier taken hebben de broncode uitgecheckt — **de opruimtaak niet.** Die haalt alleen de publicatietak op.

Gevolg: het verwijderen van `dev/pr-208/` werd wél vastgelegd maar **nooit gepubliceerd**. De proefomgeving van een gesloten voorstel blijft dus staan, en elke volgende sluiting faalt opnieuw op dezelfde regel.

## Wat er verandert

De opruimtaak checkt de broncode van `main` uit, net als de andere drie taken.

En een test erbij die precies dit telt: **elke taak die het publiceerscript aanroept, moet de broncode hebben.** Dat was wat niemand controleerde — de test van #205 keek naar het gedrag van het script zelf, niet naar de vraag of het überhaupt gevonden kon worden.

## Wat dit zegt over de beoordeling van #205

Ik heb #205 zelf nagelopen en positief geadviseerd, en Reviewer keurde hem goed. We hebben allebei gekeken naar wat het script doet en geen van beiden naar of elke aanroeper hem kan vinden. Reviewer kon de pagina toen ook al niet laden (#206), dus er is niets in de praktijk geprobeerd.

Dat is de derde keer vandaag dat iets misging omdat een vaste lijst of een vast pad uit de pas liep met de werkelijkheid.

## Wat er nog handmatig moet

`dev/pr-208/` staat nog op de publicatietak. Na het samenvoegen ruimt de volgende sluiting hem niet vanzelf op — die map hoort met de hand weg, of bij de eerstvolgende gesloten pull request.
